### PR TITLE
Fix for I2C Wire.begin() non-blocking issue

### DIFF
--- a/arm/libraries/SPI/src/HW_SPI.cpp
+++ b/arm/libraries/SPI/src/HW_SPI.cpp
@@ -244,6 +244,12 @@ void SPIClass::setClockDivider(uint8_t div)
 
 uint8_t SPIClass::transfer(uint8_t data_out)
 {
+    // Check if desire USIC channel is already in use
+	if((XMC_SPI_config->channel->CCR & USIC_CH_CCR_MODE_Msk) != XMC_USIC_CH_OPERATING_MODE_SPI)
+	{
+		SPI.begin();
+	}
+	
     uint8_t data_in = 0;
 
     /* Clear RBF0 */

--- a/arm/libraries/Wire/src/Wire.cpp
+++ b/arm/libraries/Wire/src/Wire.cpp
@@ -279,7 +279,7 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
     {
         XMC_I2C_CH_MasterReceiveAck(XMC_I2C_config->channel);
 
-		// Wait for ACK, leave when NACK is detected
+		// Wait for Receive, leave when NACK is detected
 		do
 		{
 			StatusFlag = XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel);
@@ -290,9 +290,6 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
 				this->hasError = false;
 				return 0;
 			}
-
-			/* wait for Receive */
-
 		}while ((StatusFlag & (XMC_I2C_CH_STATUS_FLAG_RECEIVE_INDICATION | XMC_I2C_CH_STATUS_FLAG_ALTERNATIVE_RECEIVE_INDICATION)) == 0U);
 		XMC_I2C_CH_ClearStatusFlag(XMC_I2C_config->channel, XMC_I2C_CH_STATUS_FLAG_RECEIVE_INDICATION | XMC_I2C_CH_STATUS_FLAG_ALTERNATIVE_RECEIVE_INDICATION);
 
@@ -301,7 +298,7 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
 
     XMC_I2C_CH_MasterReceiveNack(XMC_I2C_config->channel);
 		
-	// Wait for ACK, leave when NACK is detected
+	// Wait for Receive, leave when NACK is detected
     do
 	{
 		StatusFlag = XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel);
@@ -312,9 +309,6 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
 			this->hasError = false;
 			return 0;
 		}
-
-		/* wait for Receive */
-
 	}while ((StatusFlag & (XMC_I2C_CH_STATUS_FLAG_RECEIVE_INDICATION | XMC_I2C_CH_STATUS_FLAG_ALTERNATIVE_RECEIVE_INDICATION)) == 0U);
     XMC_I2C_CH_ClearStatusFlag(XMC_I2C_config->channel, XMC_I2C_CH_STATUS_FLAG_RECEIVE_INDICATION | XMC_I2C_CH_STATUS_FLAG_ALTERNATIVE_RECEIVE_INDICATION);
 
@@ -492,6 +486,17 @@ size_t TwoWire::write(uint8_t data)
     {
         // in slave send mode
         // reply to master
+		if( (XMC_I2C_config->channel->CCR & USIC_CH_CCR_MODE_Msk) != XMC_USIC_CH_OPERATING_MODE_I2C )
+		{
+			if(isMaster)
+			{
+				Wire.begin();
+			}
+			else
+			{
+				Wire.begin(slaveAddress);
+			}
+	    }
 
         XMC_USIC_CH_SetTransmitBufferStatus(XMC_I2C_config->channel, XMC_USIC_CH_TBUF_STATUS_SET_IDLE);
 
@@ -527,6 +532,17 @@ size_t TwoWire::write(const uint8_t* data, size_t quantity)
     {
         // in slave send mode
         // reply to master
+		if( (XMC_I2C_config->channel->CCR & USIC_CH_CCR_MODE_Msk) != XMC_USIC_CH_OPERATING_MODE_I2C )
+		{
+			if(isMaster)
+			{
+				Wire.begin();
+			}
+			else
+			{
+				Wire.begin(slaveAddress);
+			}
+	    }
 
         XMC_USIC_CH_SetTransmitBufferStatus(XMC_I2C_config->channel, XMC_USIC_CH_TBUF_STATUS_SET_IDLE);
 


### PR DESCRIPTION
Added Wire.begin in Wire.write function to reinitialize I2C when USIC
was used in another way. Should fix #14.