### PR TITLE
FIXED micros() Bug

### DIFF
--- a/arm/cores/Tone.cpp
+++ b/arm/cores/Tone.cpp
@@ -26,7 +26,7 @@
 //****************************************************************************
 // @Macros
 //****************************************************************************
-#define FREQUENCY_TO_MICROS(f)   (1000000/(2*f)
+#define FREQUENCY_TO_MILLIS(f)   (1000/(2*f)
 #define TIMER_TO_IRQ_HANDLER(t)  t==0?TIMER_0_IRQHandler:t==1?TIMER_1_IRQHandler:t==2?TIMER_2_IRQHandler:t==3?TIMER_3_IRQHandler:NULL
 
 //****************************************************************************
@@ -105,7 +105,7 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
             toggle_count = -1;
         }
 
-        timer_ids[_timer] = XMC_SYSTIMER_CreateTimer((uint32_t)FREQUENCY_TO_MICROS(frequency)), XMC_SYSTIMER_MODE_PERIODIC, (XMC_SYSTIMER_CALLBACK_t) (TIMER_TO_IRQ_HANDLER(_timer)), NULL);
+        timer_ids[_timer] = XMC_SYSTIMER_CreateTimer((uint32_t)FREQUENCY_TO_MILLIS(frequency)), XMC_SYSTIMER_MODE_PERIODIC, (XMC_SYSTIMER_CALLBACK_t) (TIMER_TO_IRQ_HANDLER(_timer)), NULL);
         if (timer_ids[_timer] != 0)
         {
             //Timer is created successfully

--- a/arm/cores/wiring_time.h
+++ b/arm/cores/wiring_time.h
@@ -186,12 +186,6 @@ extern "C" {
     XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_DeleteTimer(uint32_t id);
 
     /*
-     * @brief Gives the current hardware SysTick time in microsecond since start of hardware SysTick timer.
-     * @return  uint32_t  returns current SysTick time in microsecond. Range: (SYSTIMER_TICK_PERIOD_US) to pow(2,32).
-     */
-    uint32_t XMC_SYSTIMER_GetTime(void);
-
-    /*
      * @brief Gives the SysTick count.
      * @return  uint32_t  returns SysTick count. Range: 0 to pow(2,32).
      */


### PR DESCRIPTION
In the previous verisions micros() only had a resolution of 1ms. This
should be fixed with this update.
Refer to #16.