### PR TITLE
Reduce compiler warnings

### DIFF
--- a/arm/cores/HardwareSerial.cpp
+++ b/arm/cores/HardwareSerial.cpp
@@ -88,11 +88,13 @@ void HardwareSerial::begin(const uint32_t speed)
     begin(speed, SERIAL_8N1);
 }
 
-void HardwareSerial::begin(const uint32_t speed, const XMC_UART_MODE_t config)
+void HardwareSerial::begin( const uint32_t speed, const XMC_UART_MODE_t config )
 {
-    XMC_UART_CH_CONFIG_t uart_ch_config = {};
+    XMC_UART_CH_CONFIG_t uart_ch_config;
+    uart_ch_config.oversampling = 0;        // Must be 0 or valid oversample for baud rate calculations
     uart_ch_config.baudrate = speed;
     uart_ch_config.data_bits = (uint8_t)(config & 0x00fU);
+    uart_ch_config.frame_length = uart_ch_config.data_bits;        // Set same as data bits length
     uart_ch_config.parity_mode = (XMC_USIC_CH_PARITY_MODE_t)(config & ~0xffU);
     uart_ch_config.stop_bits = (uint8_t)((config & 0x0f0U) >> 4);
 

--- a/arm/cores/HardwareSerial.h
+++ b/arm/cores/HardwareSerial.h
@@ -131,7 +131,6 @@ extern HardwareSerial Serial;
 extern HardwareSerial Serial1;
 #endif
 
-
 #endif
 
 #endif /* HardwareSerial_h */

--- a/arm/cores/RingBuffer.cpp
+++ b/arm/cores/RingBuffer.cpp
@@ -20,7 +20,6 @@
 // @Project Includes
 //****************************************************************************
 #include "RingBuffer.h"
-#include <string.h>
 
 //****************************************************************************
 // @Local Functions
@@ -30,7 +29,6 @@
 
 RingBuffer::RingBuffer( void )
 {
-    memset( (void*)_aucBuffer, 0, SERIAL_BUFFER_SIZE ) ;
     _iHead = 0 ;
     _iTail = 0 ;
 }

--- a/arm/cores/Tone.cpp
+++ b/arm/cores/Tone.cpp
@@ -26,7 +26,7 @@
 //****************************************************************************
 // @Macros
 //****************************************************************************
-#define FREQUENCY_TO_MILLIS(f)   (1000/(2*f)
+#define FREQUENCY_TO_MICROS(f)   (1000000/(2*f)
 #define TIMER_TO_IRQ_HANDLER(t)  t==0?TIMER_0_IRQHandler:t==1?TIMER_1_IRQHandler:t==2?TIMER_2_IRQHandler:t==3?TIMER_3_IRQHandler:NULL
 
 //****************************************************************************
@@ -50,7 +50,7 @@ void TIMER_1_IRQHandler(void);
 void TIMER_2_IRQHandler(void);
 void TIMER_3_IRQHandler(void);
 
-void timer_irq_action(uint8_t);
+void timer_irq_action( int8_t );
 
 //****************************************************************************
 // @Local Functions
@@ -105,7 +105,7 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
             toggle_count = -1;
         }
 
-        timer_ids[_timer] = XMC_SYSTIMER_CreateTimer((uint32_t)FREQUENCY_TO_MILLIS(frequency)), XMC_SYSTIMER_MODE_PERIODIC, (XMC_SYSTIMER_CALLBACK_t) (TIMER_TO_IRQ_HANDLER(_timer)), NULL);
+        timer_ids[_timer] = XMC_SYSTIMER_CreateTimer((uint32_t)FREQUENCY_TO_MICROS(frequency)), XMC_SYSTIMER_MODE_PERIODIC, (XMC_SYSTIMER_CALLBACK_t) (TIMER_TO_IRQ_HANDLER(_timer)), NULL);
         if (timer_ids[_timer] != 0)
         {
             //Timer is created successfully
@@ -115,7 +115,7 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
     }
 }
 
-void disableTimer(uint8_t _timer)
+void disableTimer( int8_t _timer )
 {
     if (_timer >= 0 && _timer < AVAILABLE_TONE_PINS)
     {
@@ -138,7 +138,7 @@ void noTone(uint8_t _pin)
         }
     }
 
-    disableTimer(_timer);
+    disableTimer( _timer );
 
     digitalWrite(_pin, 0);
 }
@@ -163,7 +163,7 @@ void TIMER_3_IRQHandler(void)
     timer_irq_action(3);
 }
 
-void timer_irq_action(uint8_t _timer)
+void timer_irq_action( int8_t _timer )
 {
     if (timer_toggle_count[_timer])
     {
@@ -172,7 +172,7 @@ void timer_irq_action(uint8_t _timer)
     }
     else
     {
-        disableTimer(_timer);
+        disableTimer( _timer );
         timer_ids[_timer] = 0;
         digitalWrite(tone_pins[_timer], LOW);
     }

--- a/arm/cores/wiring_analog.c
+++ b/arm/cores/wiring_analog.c
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // @Project Includes
 //****************************************************************************
 #include "Arduino.h"
+#include <string.h>
 
 //****************************************************************************
 // @Defines
@@ -37,7 +38,8 @@ static uint8_t _writeResolution = 8;
 void wiring_analog_init(void)
 {
     /* Initialization data of VADC Global resources */
-    XMC_VADC_GLOBAL_CONFIG_t vadc_global_config = {0};
+    XMC_VADC_GLOBAL_CONFIG_t vadc_global_config;
+    memset( &vadc_global_config, 0, sizeof( XMC_VADC_GLOBAL_CONFIG_t ) );
     vadc_global_config.class0.conversion_mode_standard = XMC_VADC_CONVMODE_12BIT;
     vadc_global_config.class1.conversion_mode_standard = XMC_VADC_CONVMODE_12BIT;
 
@@ -48,7 +50,8 @@ void wiring_analog_init(void)
 
 #if(XMC_VADC_GROUP_AVAILABLE == 1U)
 // ADC grouping
-    XMC_VADC_GROUP_CONFIG_t vadc_group_config = {0};
+    XMC_VADC_GROUP_CONFIG_t vadc_group_config;
+    memset( &vadc_group_config, 0, sizeof( XMC_VADC_GROUP_CONFIG_t ) );
     vadc_group_config.class0.conversion_mode_standard = XMC_VADC_CONVMODE_12BIT;
     vadc_group_config.class1.conversion_mode_standard = XMC_VADC_CONVMODE_12BIT;
 
@@ -122,12 +125,13 @@ uint32_t analogRead(uint8_t pin)
 // ADC grouping
         if (!(adc->enabled))
         {
-            XMC_VADC_CHANNEL_CONFIG_t  vadc_gobal_channel_config = {0};
+            XMC_VADC_CHANNEL_CONFIG_t  vadc_gobal_channel_config;
+            memset( &vadc_gobal_channel_config, 0, sizeof( XMC_VADC_CHANNEL_CONFIG_t ) );
             vadc_gobal_channel_config.input_class       = XMC_VADC_CHANNEL_CONV_GROUP_CLASS1;
             vadc_gobal_channel_config.result_reg_number = adc->result_reg_num;
             vadc_gobal_channel_config.alias_channel     = XMC_VADC_CHANNEL_ALIAS_DISABLED;
 
-            XMC_VADC_RESULT_CONFIG_t vadc_gobal_result_config = {0};
+            XMC_VADC_RESULT_CONFIG_t vadc_gobal_result_config = { .g_rcr = 0 };
 
             /* Configure a channel belonging to the aforesaid conversion kernel */
             XMC_VADC_GROUP_ChannelInit(adc->group, adc->channel_num, &vadc_gobal_channel_config);
@@ -169,14 +173,15 @@ void analogWrite(uint8_t pin, uint16_t value)
         uint8_t pwm4_num = digitalPinToPWM4Num(pin);
         XMC_PWM4_t *pwm4 = &mapping_pwm4[pwm4_num];
 
-        if (!(pwm4->enabled))
+        if( !(pwm4->enabled) )
         {
             // Slice not yet initialized
-            XMC_CCU4_SLICE_COMPARE_CONFIG_t pwm_config = {0};
+            XMC_CCU4_SLICE_COMPARE_CONFIG_t pwm_config;
+            memset( &pwm_config, 0, sizeof( XMC_CCU4_SLICE_COMPARE_CONFIG_t ) );
             pwm_config.passive_level = XMC_CCU4_SLICE_OUTPUT_PASSIVE_LEVEL_HIGH;
             pwm_config.prescaler_initval = pwm4->prescaler;
 
-            XMC_CCU4_Init(pwm4->ccu, XMC_CCU4_SLICE_MCMS_ACTION_TRANSFER_PR_CR);
+            XMC_CCU4_Init( pwm4->ccu, XMC_CCU4_SLICE_MCMS_ACTION_TRANSFER_PR_CR );
 
             XMC_CCU4_SLICE_CompareInit(pwm4->slice, &pwm_config);
 
@@ -209,7 +214,8 @@ void analogWrite(uint8_t pin, uint16_t value)
         if (!(pwm8->enabled))
         {
             // Slice not yet initialized
-            XMC_CCU8_SLICE_COMPARE_CONFIG_t pwm_config = {0};
+            XMC_CCU8_SLICE_COMPARE_CONFIG_t pwm_config;
+            memset( &pwm_config, 0, sizeof( XMC_CCU8_SLICE_COMPARE_CONFIG_t ) );
             pwm_config.passive_level_out0 = XMC_CCU8_SLICE_OUTPUT_PASSIVE_LEVEL_HIGH;
             pwm_config.passive_level_out1 = XMC_CCU8_SLICE_OUTPUT_PASSIVE_LEVEL_HIGH;
             pwm_config.passive_level_out2 = XMC_CCU8_SLICE_OUTPUT_PASSIVE_LEVEL_HIGH;

--- a/arm/cores/wiring_constants.h
+++ b/arm/cores/wiring_constants.h
@@ -31,8 +31,6 @@ extern "C" {
 #define LOW             0
 #define ENABLED         1
 #define DISABLED        0
-#define true            1
-#define false           0
 #define INPUT           XMC_GPIO_MODE_INPUT_TRISTATE
 #define OUTPUT          XMC_GPIO_MODE_OUTPUT_PUSH_PULL
 #define INPUT_PULLUP    XMC_GPIO_MODE_INPUT_PULL_UP

--- a/arm/cores/wiring_digital.c
+++ b/arm/cores/wiring_digital.c
@@ -21,9 +21,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 //****************************************************************************
 #include "Arduino.h"
 
-void pinMode(uint8_t pin, uint8_t mode)
+void pinMode( uint8_t pin, uint8_t mode )
 {
-    XMC_GPIO_CONFIG_t gpio_conf = {};
+    XMC_GPIO_CONFIG_t gpio_conf;
     gpio_conf.mode = mode;
 
     XMC_GPIO_Init(mapping_port_pin[pin].port, mapping_port_pin[pin].pin, &gpio_conf);

--- a/arm/cores/wiring_digital.c
+++ b/arm/cores/wiring_digital.c
@@ -29,19 +29,19 @@ void pinMode(uint8_t pin, uint8_t mode)
     XMC_GPIO_Init(mapping_port_pin[pin].port, mapping_port_pin[pin].pin, &gpio_conf);
 }
 
-inline uint8_t digitalRead(uint8_t pin)
+uint8_t digitalRead(uint8_t pin)
 {
     uint32_t val = (pin == GND) ? LOW : XMC_GPIO_GetInput(mapping_port_pin[pin].port, mapping_port_pin[pin].pin);
     return ((val ? HIGH : LOW));
 }
 
-inline void digitalWrite(uint8_t pin, uint8_t value)
+void digitalWrite(uint8_t pin, uint8_t value)
 {
     XMC_GPIO_SetOutputLevel(mapping_port_pin[pin].port, mapping_port_pin[pin].pin, (value == LOW) ? XMC_GPIO_OUTPUT_LEVEL_LOW : XMC_GPIO_OUTPUT_LEVEL_HIGH);
 
 }
 
-inline void digitalToggle(uint8_t pin)
+void digitalToggle(uint8_t pin)
 {
     XMC_GPIO_ToggleOutput(mapping_port_pin[pin].port, mapping_port_pin[pin].pin);
 

--- a/arm/cores/wiring_digital.h
+++ b/arm/cores/wiring_digital.h
@@ -55,7 +55,7 @@ extern "C" {
      * \param pin the pin number
      * \param val HIGH or LOW
      */
-    extern inline void digitalWrite(uint8_t pin, uint8_t val);
+    extern void digitalWrite(uint8_t pin, uint8_t val);
 
     /*
      * \brief Reads the value from a specified digital pin, either HIGH or LOW.
@@ -64,14 +64,14 @@ extern "C" {
      *
      * \return HIGH or LOW
      */
-    extern inline uint8_t digitalRead(uint8_t pin);
+    extern uint8_t digitalRead(uint8_t pin);
 
     /*
      * \brief Toggles output signal of a digital pin.
      *
      * \param pin The number of the pin who you want to toggle
      */
-    extern inline void digitalToggle(uint8_t pin);
+    extern void digitalToggle(uint8_t pin);
 
 #ifdef __cplusplus
 }

--- a/arm/cores/xmc_lib/XMCLib/inc/xmc_eth_mac.h
+++ b/arm/cores/xmc_lib/XMCLib/inc/xmc_eth_mac.h
@@ -405,7 +405,6 @@ void XMC_ETH_MAC_InitRxDescriptors(XMC_ETH_MAC_t *const eth_mac);
 void XMC_ETH_MAC_InitTxDescriptors(XMC_ETH_MAC_t *const eth_mac);
  
 /**
- * @param eth_mac A constant pointer to XMC_ETH_MAC_t, pointing to the ETH MAC base address
  * @return None
  *
  * \par<b>Description: </b><br>
@@ -414,10 +413,9 @@ void XMC_ETH_MAC_InitTxDescriptors(XMC_ETH_MAC_t *const eth_mac);
  * \par
  * The function de-asserts the peripheral reset.
  */
-void XMC_ETH_MAC_Enable(XMC_ETH_MAC_t *const eth_mac);
+void XMC_ETH_MAC_Enable( );
 
 /**
- * @param eth_mac A constant pointer to XMC_ETH_MAC_t, pointing to the ETH MAC base address
  * @return None
  *
  * \par<b>Description: </b><br>
@@ -426,7 +424,7 @@ void XMC_ETH_MAC_Enable(XMC_ETH_MAC_t *const eth_mac);
  * \par
  * The function asserts the peripheral reset.
  */
-void XMC_ETH_MAC_Disable(XMC_ETH_MAC_t *const eth_mac);
+void XMC_ETH_MAC_Disable( );
 
 /**
  * @param eth_mac A constant pointer to XMC_ETH_MAC_t, pointing to the ETH MAC base address
@@ -492,7 +490,6 @@ XMC_ETH_MAC_STATUS_t XMC_ETH_MAC_ReadPhy(XMC_ETH_MAC_t *const eth_mac, uint8_t p
 XMC_ETH_MAC_STATUS_t XMC_ETH_MAC_WritePhy(XMC_ETH_MAC_t *const eth_mac, uint8_t phy_addr, uint8_t reg_addr, uint16_t data);
 
 /**
- * @param eth_mac A constant pointer to XMC_ETH_MAC_t, pointing to the ETH MAC base address
  * @param port_ctrl Port control configuration
  * @return None
  *
@@ -510,7 +507,7 @@ XMC_ETH_MAC_STATUS_t XMC_ETH_MAC_WritePhy(XMC_ETH_MAC_t *const eth_mac, uint8_t 
  * - XMC4800 LQFP144 and BGA196 packages
  *
  */
-__STATIC_INLINE void XMC_ETH_MAC_SetPortControl(XMC_ETH_MAC_t *const eth_mac, const XMC_ETH_MAC_PORT_CTRL_t port_ctrl)
+__STATIC_INLINE void XMC_ETH_MAC_SetPortControl( const XMC_ETH_MAC_PORT_CTRL_t port_ctrl )
 {
   ETH0_CON->CON = (uint32_t)port_ctrl.raw;
 }

--- a/arm/cores/xmc_lib/XMCLib/inc/xmc_sdmmc.h
+++ b/arm/cores/xmc_lib/XMCLib/inc/xmc_sdmmc.h
@@ -560,7 +560,6 @@ extern "C" {
 #endif
 
 /**
- * @param sdmmc A constant pointer to XMC_SDMMC_t, pointing to the SDMMC base address
  * @return bool
  *
  * \par<b>Description: </b><br>
@@ -570,10 +569,9 @@ extern "C" {
  * The function checks the SD_BUS_POWER bit-field of the POWER_CTRL register and returns
  * a boolean value - "on" or "off".
  */
-bool XMC_SDMMC_GetPowerStatus(XMC_SDMMC_t *const sdmmc);
+bool XMC_SDMMC_GetPowerStatus( );
 
 /**
- * @param sdmmc A constant pointer to XMC_SDMMC_t, pointing to the SDMMC base address
  * @return None
  *
  * \par<b>Description: </b><br>
@@ -582,10 +580,9 @@ bool XMC_SDMMC_GetPowerStatus(XMC_SDMMC_t *const sdmmc);
  * \par
  * The function de-asserts the peripheral reset. The peripheral needs to be initialized.
  */
-void XMC_SDMMC_Enable(XMC_SDMMC_t *const sdmmc);
+void XMC_SDMMC_Enable( );
 
 /**
- * @param sdmmc A constant pointer to XMC_SDMMC_t, pointing to the SDMMC base address
  * @return None
  *
  * \par<b>Description: </b><br>
@@ -594,7 +591,7 @@ void XMC_SDMMC_Enable(XMC_SDMMC_t *const sdmmc);
  * \par
  * The function asserts the peripheral reset.
  */
-void XMC_SDMMC_Disable(XMC_SDMMC_t *const sdmmc);
+void XMC_SDMMC_Disable( );
 
 /**
  * @param sdmmc A constant pointer to XMC_SDMMC_t, pointing to the SDMMC base address
@@ -1326,7 +1323,6 @@ __STATIC_INLINE bool XMC_SDMMC_GetContinueRequest(XMC_SDMMC_t *const sdmmc)
 
 /**
  * @param sdmmc A constant pointer to XMC_SDMMC_t, pointing to the SDMMC base address
- * @param config A pointer to the SDMMC configuration structure (::XMC_SDMMC_CONFIG_t)
  * @return None
  *
  * \par<b>Description: </b><br>
@@ -1337,18 +1333,15 @@ __STATIC_INLINE bool XMC_SDMMC_GetContinueRequest(XMC_SDMMC_t *const sdmmc)
  * at block gap for a multi-block transfer. This bit is only valid in a 4-bit mode of
  * the SDIO card.
  */
-__STATIC_INLINE void XMC_SDMMC_EnableInterruptAtBlockGap(XMC_SDMMC_t *const sdmmc, const XMC_SDMMC_CONFIG_t *config)
+__STATIC_INLINE void XMC_SDMMC_EnableInterruptAtBlockGap(XMC_SDMMC_t *const sdmmc )
 {
   XMC_ASSERT("XMC_SDMMC_EnableInterruptAtBlockGap: Invalid module pointer", XMC_SDMMC_CHECK_MODULE_PTR(sdmmc));
-  XMC_ASSERT("XMC_SDMMC_EnableInterruptAtBlockGap: This operation is only valid in 4-bit mode",
-             (config->bus_width == XMC_SDMMC_DATA_LINES_1));
 
   sdmmc->BLOCK_GAP_CTRL |= (uint8_t)SDMMC_BLOCK_GAP_CTRL_INT_AT_BLOCK_GAP_Msk;
 }
 
 /**
  * @param sdmmc A constant pointer to XMC_SDMMC_t, pointing to the SDMMC base address
- * @param config A pointer to the SDMMC configuration structure (::XMC_SDMMC_CONFIG_t)
  * @return None
  *
  * \par<b>Description: </b><br>
@@ -1358,13 +1351,9 @@ __STATIC_INLINE void XMC_SDMMC_EnableInterruptAtBlockGap(XMC_SDMMC_t *const sdmm
  * The function resets the BLOCK_GAP_CTRL.INT_AT_BLOCK_GAP bit-field to disable interrupt
  * at block gap. This bit is only valid in a 4-bit mode of the SDIO card.
  */
-__STATIC_INLINE void XMC_SDMMC_DisableInterruptAtBlockGap(XMC_SDMMC_t *const sdmmc,
-                                                          const XMC_SDMMC_CONFIG_t *config)
-
+__STATIC_INLINE void XMC_SDMMC_DisableInterruptAtBlockGap(XMC_SDMMC_t *const sdmmc )
 {
   XMC_ASSERT("XMC_SDMMC_EnableInterruptAtBlockGap: Invalid module pointer", XMC_SDMMC_CHECK_MODULE_PTR(sdmmc));
-  XMC_ASSERT("XMC_SDMMC_EnableInterruptAtBlockGap: This operation is only valid in 4-bit mode",
-             (config->bus_width == XMC_SDMMC_DATA_LINES_1));
 
   sdmmc->BLOCK_GAP_CTRL &= (uint8_t)~SDMMC_BLOCK_GAP_CTRL_INT_AT_BLOCK_GAP_Msk;
 }

--- a/arm/cores/xmc_lib/XMCLib/inc/xmc_usbh.h
+++ b/arm/cores/xmc_lib/XMCLib/inc/xmc_usbh.h
@@ -358,7 +358,6 @@ extern "C" {
  */
 void XMC_USBH_HandleIrq (uint32_t gintsts);
 /**
- * @param ms Delay in milliseconds.
  * @return uint8_t Value has no significance for the low level driver.
  *
  * \par<b>Description:</b><br>
@@ -366,7 +365,7 @@ void XMC_USBH_HandleIrq (uint32_t gintsts);
  * for delay which has to re-implemented with time delay logic. The low level driver expects blocking
  * implementation of the delay.
  */
- uint8_t XMC_USBH_osDelay(uint32_t ms);
+ uint8_t XMC_USBH_osDelay( );
  
 /**
  * @param port Address of the port which has the pin used to enable VBUS charge pump.

--- a/arm/cores/xmc_lib/XMCLib/src/xmc_eth_mac.c
+++ b/arm/cores/xmc_lib/XMCLib/src/xmc_eth_mac.c
@@ -471,7 +471,7 @@ XMC_ETH_MAC_STATUS_t XMC_ETH_MAC_SetManagmentClockDivider(XMC_ETH_MAC_t *const e
 }
 
 /* ETH MAC enable */
-void XMC_ETH_MAC_Enable(XMC_ETH_MAC_t *const eth_mac)
+void XMC_ETH_MAC_Enable( )
 {
   XMC_SCU_CLOCK_EnableClock(XMC_SCU_CLOCK_ETH);
 #if UC_DEVICE != XMC4500
@@ -481,7 +481,7 @@ void XMC_ETH_MAC_Enable(XMC_ETH_MAC_t *const eth_mac)
 }
 
 /* ETH MAC disable */
-void XMC_ETH_MAC_Disable(XMC_ETH_MAC_t *const eth_mac)
+void XMC_ETH_MAC_Disable( )
 {
   XMC_SCU_RESET_AssertPeripheralReset(XMC_SCU_PERIPHERAL_RESET_ETH0);
 #if UC_DEVICE != XMC4500

--- a/arm/cores/xmc_lib/XMCLib/src/xmc_sdmmc.c
+++ b/arm/cores/xmc_lib/XMCLib/src/xmc_sdmmc.c
@@ -171,10 +171,8 @@ bool XMC_SDMMC_GetPowerStatus(XMC_SDMMC_t *const sdmmc)
  * De-assert the peripheral reset. The SDMMC peripheral
  * needs to be initialized
  */
-void XMC_SDMMC_Enable(XMC_SDMMC_t *const sdmmc)
+void XMC_SDMMC_Enable( )
 {
-  XMC_ASSERT("XMC_SDMMC_Enable: Invalid module pointer", XMC_SDMMC_CHECK_MODULE_PTR(sdmmc));
-
 #if defined(CLOCK_GATING_SUPPORTED)
   XMC_SCU_CLOCK_UngatePeripheralClock(XMC_SCU_PERIPHERAL_CLOCK_SDMMC);
 #endif
@@ -184,10 +182,8 @@ void XMC_SDMMC_Enable(XMC_SDMMC_t *const sdmmc)
 }
 
 /* Assert the peripheral reset */
-void XMC_SDMMC_Disable(XMC_SDMMC_t *const sdmmc)
+void XMC_SDMMC_Disable( )
 {
-  XMC_ASSERT("XMC_SDMMC_Disable: Invalid module pointer", XMC_SDMMC_CHECK_MODULE_PTR(sdmmc));
-
 #if defined(PERIPHERAL_RESET_SUPPORTED)
   XMC_SCU_RESET_AssertPeripheralReset(XMC_SCU_PERIPHERAL_RESET_SDMMC);
 #endif  

--- a/arm/cores/xmc_lib/XMCLib/src/xmc_usbh.c
+++ b/arm/cores/xmc_lib/XMCLib/src/xmc_usbh.c
@@ -721,7 +721,11 @@ static XMC_USBH_PORT_STATE_t XMC_USBH_PortGetState (uint8_t port)
  * \par<b>Related APIs:</b><BR>
  * XMC_USBH_PipeModify(), XMC_USBH_PipeDelete(), XMC_USBH_PipeReset(), XMC_USBH_PipeTransfer() \n
 */
-static XMC_USBH_PIPE_HANDLE XMC_USBH_PipeCreate (uint8_t dev_addr, uint8_t dev_speed, uint8_t hub_addr, uint8_t hub_port, uint8_t ep_addr, uint8_t ep_type, uint16_t ep_max_packet_size, uint8_t  ep_interval) {
+static XMC_USBH_PIPE_HANDLE XMC_USBH_PipeCreate( uint8_t dev_addr, uint8_t dev_speed, 
+                                                  uint8_t hub_addr, uint8_t hub_port, 
+                                                  uint8_t ep_addr, uint8_t ep_type, 
+                                                  uint16_t ep_max_packet_size, uint8_t  ep_interval )
+{
   XMC_USBH0_pipe_t    *ptr_pipe;
   USB0_CH_TypeDef *ptr_ch;
   uint32_t         i;
@@ -806,7 +810,10 @@ static XMC_USBH_PIPE_HANDLE XMC_USBH_PipeCreate (uint8_t dev_addr, uint8_t dev_s
  * \par<b>Related APIs:</b><BR>
  * XMC_USBH_PipeCreate(), XMC_USBH_PipeDelete(), XMC_USBH_PipeReset(), XMC_USBH_PipeTransfer() \n
 */
-static int32_t XMC_USBH_PipeModify (XMC_USBH_PIPE_HANDLE pipe_hndl, uint8_t dev_addr, uint8_t dev_speed, uint8_t hub_addr, uint8_t hub_port, uint16_t ep_max_packet_size) {
+static int32_t XMC_USBH_PipeModify (XMC_USBH_PIPE_HANDLE pipe_hndl, uint8_t dev_addr, 
+                                          uint8_t dev_speed, uint8_t hub_addr, uint8_t hub_port, 
+                                          uint16_t ep_max_packet_size)
+{
   XMC_USBH0_pipe_t    *ptr_pipe;
   USB0_CH_TypeDef *ptr_ch;
   uint32_t   hcchar;
@@ -1475,7 +1482,7 @@ XMC_USBH_DRIVER_t Driver_USBH0 = {
 
 
 /*Weak definition of delay function*/
-__WEAK uint8_t XMC_USBH_osDelay(uint32_t MS)
+__WEAK uint8_t XMC_USBH_osDelay( )
 {
   /*A precise time delay implementation for this function has to be provided*/
   while (1)

--- a/arm/variants/XMC1100/config/XMC1100_Boot_Kit/pins_arduino.h
+++ b/arm/variants/XMC1100/config/XMC1100_Boot_Kit/pins_arduino.h
@@ -39,6 +39,9 @@
 #define NUM_INTERRUPT       2
 #define NUM_SERIAL          1
 
+// comment out following line to use Serial on pins (board)
+#define SERIAL_DEBUG    1
+
 #define PWM4_TIMER_PERIOD (2041U)  // Generate 490Hz @fCCU=1MHz
 
 #define PIN_RX        (0)
@@ -161,72 +164,49 @@ XMC_ADC_t mapping_adc[] =
 /*
  * UART objects
  */
-RingBuffer rx_buffer_debug;
-RingBuffer tx_buffer_debug;
-//RingBuffer rx_buffer_on_board;
-//RingBuffer tx_buffer_on_board;
+RingBuffer rx_buffer_0;
+RingBuffer tx_buffer_0;
 
-XMC_UART_t XMC_UART_debug =
-{
-    .channel              = XMC_UART0_CH1,
-    .rx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
-        .pin  = (uint8_t)3
-    },
-    .rx_config            = {
-        .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
-        .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD
-    },
-    .tx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
-        .pin  = (uint8_t)2
-    },
-    .tx_config            = {
-        .mode = (XMC_GPIO_MODE_t) XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT7,
-        .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
-        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH
-    },
-    .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C1_DX0_P1_3,
-    .input_source_dx1     = XMC_INPUT_INVALID,
-    .input_source_dx2     = XMC_INPUT_INVALID,
-    .input_source_dx3     = XMC_INPUT_INVALID,
-    .irq_num              = USIC0_0_IRQn,
-    .irq_service_request  = 0
-};
+/* First UART channel pins are swapped between debug and  normal use */
+XMC_UART_t XMC_UART_0 =
+  {
+  .channel              = XMC_UART0_CH1,
+  .rx                   = { .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
+#ifdef SERIAL_DEBUG
+                            .pin  = (uint8_t)3
+#else
+                            .pin  = (uint8_t)2
+#endif
+                          },
+  .rx_config            = { .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
+                            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
+                            .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH
+                          },
+  .tx                   = { .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
+#ifdef SERIAL_DEBUG
+                            .pin  = (uint8_t)2
+#else
+                            .pin  = (uint8_t)3
+#endif
+                          },
+  .tx_config            = { .mode = (XMC_GPIO_MODE_t) XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT7,
+                            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
+                            .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH
+                          },
+#ifdef SERIAL_DEBUG
+  .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C1_DX0_P1_3,
+#else
+  .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C0_DX0_P1_2,
+#endif
+  .input_source_dx1     = XMC_INPUT_INVALID,
+  .input_source_dx2     = XMC_INPUT_INVALID,
+  .input_source_dx3     = XMC_INPUT_INVALID,
+  .irq_num              = USIC0_0_IRQn,
+  .irq_service_request  = 0
+  };
 
-XMC_UART_t XMC_UART_on_board =
-{
-    .channel              = XMC_UART0_CH1,
-    .rx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
-        .pin  = (uint8_t)2
-    },
-    .rx_config            = {
-        .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
-        .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD
-    },
-    .tx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
-        .pin  = (uint8_t)3
-    },
-    .tx_config            = {
-        .mode = (XMC_GPIO_MODE_t) XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT7,
-        .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
-        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH
-    },
-    .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C1_DX0_P1_2,
-    .input_source_dx1     = XMC_INPUT_INVALID,
-    .input_source_dx2     = XMC_INPUT_INVALID,
-    .input_source_dx3     = XMC_INPUT_INVALID,
-    .irq_num              = USIC0_0_IRQn,
-    .irq_service_request  = 0
-};
-
-HardwareSerial Serial(&XMC_UART_debug, &rx_buffer_debug, &tx_buffer_debug);
-//HardwareSerial Serial(&XMC_UART_on_board, &rx_buffer_on_board, &tx_buffer_on_board);
-
+HardwareSerial Serial( &XMC_UART_0, &rx_buffer_0, &tx_buffer_0 );
 
 #endif
-
 
 #endif

--- a/arm/variants/XMC1100/config/XMC1100_XMC2GO/pins_arduino.h
+++ b/arm/variants/XMC1100/config/XMC1100_XMC2GO/pins_arduino.h
@@ -39,6 +39,9 @@
 #define NUM_INTERRUPT       1
 #define NUM_SERIAL          1
 
+// comment out following line to use Serial on pins (board)
+#define SERIAL_DEBUG    1
+
 #define PWM4_TIMER_PERIOD (2041U)  // Generate 490Hz @fCCU=1MHz
 
 #define PIN_RX        (7)
@@ -120,73 +123,49 @@ XMC_ADC_t mapping_adc[] =
 /*
  * UART objects
  */
-RingBuffer rx_buffer_debug;
-RingBuffer tx_buffer_debug;
-//RingBuffer rx_buffer_on_board;
-//RingBuffer tx_buffer_on_board;
+RingBuffer rx_buffer_0;
+RingBuffer tx_buffer_0;
 
-XMC_UART_t XMC_UART_debug =
-{
-    .channel              = XMC_UART0_CH0,
-    .rx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT2_BASE,
-        .pin  = (uint8_t)2
-    },
-    .rx_config            = {
-        .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
-        .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
-        .output_level     = XMC_GPIO_OUTPUT_LEVEL_HIGH
-    },
-    .tx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT2_BASE,
-        .pin  = (uint8_t)1
-    },
-    .tx_config            = {
-        .mode = (XMC_GPIO_MODE_t) XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT6,
-        .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
-        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH
-    },
-    .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C0_DX0_DX3INS,
-    .input_source_dx1     = XMC_INPUT_INVALID,
-    .input_source_dx2     = XMC_INPUT_INVALID,
-    .input_source_dx3     = (XMC_USIC_INPUT_t)USIC0_C0_DX3_P2_2,
-    .irq_num              = USIC0_0_IRQn,
-    .irq_service_request  = 0
-};
+/* First UART channel pins are swapped between debug and  normal use */
+XMC_UART_t XMC_UART_0 =
+  {
+  .channel              = XMC_UART0_CH0,
+  .rx                   = { .port = (XMC_GPIO_PORT_t*)PORT2_BASE,
+#ifdef SERIAL_DEBUG
+                            .pin  = (uint8_t)2
+#else
+                            .pin  = (uint8_t)6
+#endif
+                          },
+  .rx_config            = { .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
+                            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
+                            .output_level     = XMC_GPIO_OUTPUT_LEVEL_HIGH
+                          },
+  .tx                   = { .port = (XMC_GPIO_PORT_t*)PORT2_BASE,
+#ifdef SERIAL_DEBUG
+                            .pin  = (uint8_t)1
+#else
+                            .pin  = (uint8_t)0
+#endif
+                          },
+  .tx_config            = { .mode = (XMC_GPIO_MODE_t) XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT6,
+                            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
+                            .output_level     = XMC_GPIO_OUTPUT_LEVEL_HIGH
+                          },
+  .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C1_DX0_P1_3,
+  .input_source_dx1     = XMC_INPUT_INVALID,
+  .input_source_dx2     = XMC_INPUT_INVALID,
+#ifdef SERIAL_DEBUG
+  .input_source_dx3     = (XMC_USIC_INPUT_t)USIC0_C0_DX3_P2_2,
+#else
+  .input_source_dx3     = (XMC_USIC_INPUT_t)USIC0_C0_DX3_P2_6,
+#endif
+  .irq_num              = USIC0_0_IRQn,
+  .irq_service_request  = 0
+  };
 
-XMC_UART_t XMC_UART_on_board =
-{
-    .channel              = XMC_UART0_CH0,
-    .rx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT2_BASE,
-        .pin  = (uint8_t)6
-    },
-    .rx_config            = {
-        .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
-        .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD
-    },
-    .tx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT2_BASE,
-        .pin  = (uint8_t)0
-    },
-    .tx_config            = {
-        .mode = (XMC_GPIO_MODE_t) XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT6,
-        .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
-        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH
-    },
-    .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C0_DX0_DX3INS,
-    .input_source_dx1     = XMC_INPUT_INVALID,
-    .input_source_dx2     = XMC_INPUT_INVALID,
-    .input_source_dx3     = (XMC_USIC_INPUT_t)USIC0_C0_DX3_P2_6,
-    .irq_num              = USIC0_0_IRQn,
-    .irq_service_request  = 0
-};
-
-HardwareSerial Serial(&XMC_UART_debug, &rx_buffer_debug, &tx_buffer_debug);
-//HardwareSerial Serial(&XMC_UART_on_board, &rx_buffer_on_board, &tx_buffer_on_board);
-
+HardwareSerial Serial( &XMC_UART_0, &rx_buffer_0, &tx_buffer_0 );
 
 #endif
-
 
 #endif

--- a/arm/variants/XMC1300/config/XMC1300_Boot_Kit/pins_arduino.h
+++ b/arm/variants/XMC1300/config/XMC1300_Boot_Kit/pins_arduino.h
@@ -39,6 +39,9 @@
 #define NUM_INTERRUPT       2
 #define NUM_SERIAL          1
 
+// comment out following line to use Serial on pins (board)
+#define SERIAL_DEBUG    1
+
 #define PWM4_TIMER_PERIOD (2041U)  // Generate 490Hz @fCCU=1MHz
 #define PWM8_TIMER_PERIOD (2041U)  // Generate 490Hz @fCCU=1MHz
 
@@ -173,72 +176,49 @@ XMC_ADC_t mapping_adc[] =
 /*
  * UART objects
  */
-RingBuffer rx_buffer_debug;
-RingBuffer tx_buffer_debug;
-//RingBuffer rx_buffer_on_board;
-//RingBuffer tx_buffer_on_board;
+RingBuffer rx_buffer_0;
+RingBuffer tx_buffer_0;
 
-XMC_UART_t XMC_UART_debug =
-{
-    .channel              = XMC_UART0_CH1,
-    .rx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
-        .pin  = (uint8_t)3
-    },
-    .rx_config            = {
-        .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
-        .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD
-    },
-    .tx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
-        .pin  = (uint8_t)2
-    },
-    .tx_config            = {
-        .mode = (XMC_GPIO_MODE_t) XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT7,
-        .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
-        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH
-    },
-    .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C1_DX0_P1_3,
-    .input_source_dx1     = XMC_INPUT_INVALID,
-    .input_source_dx2     = XMC_INPUT_INVALID,
-    .input_source_dx3     = XMC_INPUT_INVALID,
-    .irq_num              = USIC0_0_IRQn,
-    .irq_service_request  = 0
-};
+/* First UART channel pins are swapped between debug and  normal use */
+XMC_UART_t XMC_UART_0 =
+  {
+  .channel              = XMC_UART0_CH1,
+  .rx                   = { .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
+#ifdef SERIAL_DEBUG
+                            .pin  = (uint8_t)3
+#else
+                            .pin  = (uint8_t)2
+#endif
+                          },
+  .rx_config            = { .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
+                            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
+                            .output_level     = XMC_GPIO_OUTPUT_LEVEL_HIGH
+                          },
+  .tx                   = { .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
+#ifdef SERIAL_DEBUG
+                            .pin  = (uint8_t)2
+#else
+                            .pin  = (uint8_t)3
+#endif
+                          },
+  .tx_config            = { .mode = (XMC_GPIO_MODE_t) XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT7,
+                            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
+                            .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH
+                          },
+#ifdef SERIAL_DEBUG
+  .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C1_DX0_P1_3,
+#else
+  .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C0_DX0_P1_2,
+#endif
+  .input_source_dx1     = XMC_INPUT_INVALID,
+  .input_source_dx2     = XMC_INPUT_INVALID,
+  .input_source_dx3     = XMC_INPUT_INVALID,
+  .irq_num              = USIC0_0_IRQn,
+  .irq_service_request  = 0
+  };
 
-XMC_UART_t XMC_UART_on_board =
-{
-    .channel              = XMC_UART0_CH1,
-    .rx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
-        .pin  = (uint8_t)2
-    },
-    .rx_config            = {
-        .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
-        .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD
-    },
-    .tx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
-        .pin  = (uint8_t)3
-    },
-    .tx_config            = {
-        .mode = (XMC_GPIO_MODE_t) XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT7,
-        .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
-        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH
-    },
-    .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C1_DX0_P1_2,
-    .input_source_dx1     = XMC_INPUT_INVALID,
-    .input_source_dx2     = XMC_INPUT_INVALID,
-    .input_source_dx3     = XMC_INPUT_INVALID,
-    .irq_num              = USIC0_0_IRQn,
-    .irq_service_request  = 0
-};
-
-HardwareSerial Serial(&XMC_UART_debug, &rx_buffer_debug, &tx_buffer_debug);
-//HardwareSerial Serial(&XMC_UART_on_board, &rx_buffer_on_board, &tx_buffer_on_board);
-
+HardwareSerial Serial( &XMC_UART_0, &rx_buffer_0, &tx_buffer_0 );
 
 #endif
-
 
 #endif

--- a/arm/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
+++ b/arm/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
@@ -39,6 +39,8 @@
 #define NUM_INTERRUPT 2
 #define NUM_SERIAL 2
 
+// Board has two serial ports pre-assigned to debug and on-board
+
 #define PWM4_TIMER_PERIOD (0x11EF)  // Generate 490Hz @fCCU=144MHz
 #define PWM8_TIMER_PERIOD (0x11EF)  // Generate 490Hz @fCCU=144MHz
 
@@ -318,75 +320,70 @@ XMC_ADC_t mapping_adc[] =
 
 /*
  * UART objects
+ *
+ * Serial [0] is Debug port
+ * Serial 1  is on-board port
  */
-RingBuffer rx_buffer_debug;
-RingBuffer tx_buffer_debug;
-RingBuffer rx_buffer_on_board;
-RingBuffer tx_buffer_on_board;
+RingBuffer rx_buffer_0;
+RingBuffer tx_buffer_0;
+RingBuffer rx_buffer_1;
+RingBuffer tx_buffer_1;
 
-XMC_UART_t XMC_UART_debug =
-{
-    .channel              = XMC_UART0_CH0,
-    .rx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
-        .pin  = (uint8_t)4
-    },
-    .rx_config            = {
-        .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
-        .output_level     = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-        .output_strength  = XMC_GPIO_OUTPUT_STRENGTH_STRONG_SOFT_EDGE
-    },
-    .tx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
-        .pin  = (uint8_t)5
-    },
-    .tx_config            = {
-        .mode = (XMC_GPIO_MODE_t) XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT2,
-        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-        .output_strength  = XMC_GPIO_OUTPUT_STRENGTH_STRONG_SOFT_EDGE
-    },
-    .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C0_DX0_P1_4,
-    .input_source_dx1     = XMC_INPUT_INVALID,
-    .input_source_dx2     = XMC_INPUT_INVALID,
-    .input_source_dx3     = XMC_INPUT_INVALID,
-    .irq_num              = USIC0_0_IRQn,
-    .irq_service_request  = 0
-};
+XMC_UART_t XMC_UART_0 =
+  {
+  .channel              = XMC_UART0_CH0,
+  .rx                   = { .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
+                            .pin  = (uint8_t)4
+                          },
+  .rx_config            = { .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
+                            .output_level     = XMC_GPIO_OUTPUT_LEVEL_HIGH,
+                            .output_strength  = XMC_GPIO_OUTPUT_STRENGTH_STRONG_SOFT_EDGE
+                          },
+  .tx                   = { .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
+                            .pin  = (uint8_t)5
+                          },
+  .tx_config            = { .mode = (XMC_GPIO_MODE_t) XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT2,
+                            .output_level     = XMC_GPIO_OUTPUT_LEVEL_HIGH,
+                            .output_strength  = XMC_GPIO_OUTPUT_STRENGTH_STRONG_SOFT_EDGE
+                          },
+  .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C0_DX0_P1_4,
+  .input_source_dx1     = XMC_INPUT_INVALID,
+  .input_source_dx2     = XMC_INPUT_INVALID,
+  .input_source_dx3     = XMC_INPUT_INVALID,
+  .irq_num              = USIC0_0_IRQn,
+  .irq_service_request  = 0
+  };
 
-XMC_UART_t XMC_UART_on_board =
-{
-    .channel              = XMC_UART1_CH0,
-    .rx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT2_BASE,
-        .pin  = (uint8_t)15
-    },
-    .rx_config            = {
-        .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
-        .output_level     = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-        .output_strength  = XMC_GPIO_OUTPUT_STRENGTH_STRONG_SOFT_EDGE
-    },
-    .tx                   = {
-        .port = (XMC_GPIO_PORT_t*)PORT2_BASE,
-        .pin  = (uint8_t)14
-    },
-    .tx_config            = {
-        .mode = (XMC_GPIO_MODE_t) XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT2,
-        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-        .output_strength  = XMC_GPIO_OUTPUT_STRENGTH_STRONG_SOFT_EDGE
-    },
-    .input_source_dx0     = (XMC_USIC_INPUT_t)USIC1_C0_DX0_P2_15,
-    .input_source_dx1     = XMC_INPUT_INVALID,
-    .input_source_dx2     = XMC_INPUT_INVALID,
-    .input_source_dx3     = XMC_INPUT_INVALID,
-    .irq_num              = USIC1_0_IRQn,
-    .irq_service_request  = 0
-};
+XMC_UART_t XMC_UART_1 =
+  {
+  .channel              = XMC_UART1_CH0,
+  .rx                   = { .port = (XMC_GPIO_PORT_t*)PORT2_BASE,
+                            .pin  = (uint8_t)15
+                          },
+  .rx_config            = { .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
+                            .output_level     = XMC_GPIO_OUTPUT_LEVEL_HIGH,
+                            .output_strength  = XMC_GPIO_OUTPUT_STRENGTH_STRONG_SOFT_EDGE
+                          },
+  .tx                   = { .port = (XMC_GPIO_PORT_t*)PORT2_BASE,
+                            .pin  = (uint8_t)14
+                          },
+  .tx_config            = { .mode = (XMC_GPIO_MODE_t) XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT2,
+                            .output_level     = XMC_GPIO_OUTPUT_LEVEL_HIGH,
+                            .output_strength  = XMC_GPIO_OUTPUT_STRENGTH_STRONG_SOFT_EDGE
+                          },
+  .input_source_dx0     = (XMC_USIC_INPUT_t)USIC1_C0_DX0_P2_15,
+  .input_source_dx1     = XMC_INPUT_INVALID,
+  .input_source_dx2     = XMC_INPUT_INVALID,
+  .input_source_dx3     = XMC_INPUT_INVALID,
+  .irq_num              = USIC1_0_IRQn,
+  .irq_service_request  = 0
+   };
 
-HardwareSerial Serial(&XMC_UART_debug, &rx_buffer_debug, &tx_buffer_debug);
-HardwareSerial Serial1(&XMC_UART_on_board, &rx_buffer_on_board, &tx_buffer_on_board);
-
+// Debug port
+HardwareSerial Serial( &XMC_UART_0, &rx_buffer_0, &tx_buffer_0 );
+// On-board port
+HardwareSerial Serial1( &XMC_UART_1, &rx_buffer_1, &tx_buffer_1 );
 
 #endif
-
 
 #endif

--- a/arm/variants/XMC4800/config/XMC4800_Relax_Kit/pins_arduino.h
+++ b/arm/variants/XMC4800/config/XMC4800_Relax_Kit/pins_arduino.h
@@ -39,6 +39,8 @@ Boston, MA  02111-1307  USA
 #define NUM_INTERRUPT 2
 #define NUM_SERIAL 2
 
+// Board has two serial ports pre-assigned to debug and on-board
+
 #define PWM4_TIMER_PERIOD (0x11EF)  // Generate 490Hz @fCCU=144MHz
 #define PWM8_TIMER_PERIOD (0x11EF)  // Generate 490Hz @fCCU=144MHz
 
@@ -186,17 +188,17 @@ XMC_UART_t XMC_UART_debug =
 							},
   .tx 					= {	.port = (XMC_GPIO_PORT_t *)PORT1_BASE,
 							.pin  = (uint8_t)5
-							},
+						  },
   .tx_config			= { .mode = (XMC_GPIO_MODE_t) XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT2,
 							.output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
 							.output_strength  = XMC_GPIO_OUTPUT_STRENGTH_STRONG_SOFT_EDGE
-							},
+						  },
   .input_source 		= (XMC_USIC_CH_INPUT_t)USIC0_C0_DX0_P1_4,
   .irq_num				= USIC0_0_IRQn,	
   .irq_service_request	= 0
 };	
 
-XMC_UART_t XMC_UART_on_board =
+XMC_UART_t XMC_UART_1 =
 {
   .channel 				= XMC_UART1_CH0,
   .rx 					= {	.port = (XMC_GPIO_PORT_t *)PORT2_BASE,
@@ -218,10 +220,11 @@ XMC_UART_t XMC_UART_on_board =
   .irq_service_request	= 0
 };	
 
-HardwareSerial Serial(&XMC_UART_debug, &rx_buffer_debug, &tx_buffer_debug);	
-HardwareSerial Serial1(&XMC_UART_on_board, &rx_buffer_on_board, &tx_buffer_on_board);	
+// Debug port
+HardwareSerial Serial( &XMC_UART_0, &rx_buffer_0, &tx_buffer_0 );
+// On-board port
+HardwareSerial Serial1( &XMC_UART_1, &rx_buffer_1, &tx_buffer_1 );
 
 #endif
-
 
 #endif


### PR DESCRIPTION
Issue #26 

First stage of multi stage commits -

First part removes redefine true/false,

Second part removes bad inlining to reduce to standard functions (compiler ignores inlining anyway) 