### PR TITLE
Final compiler warnings fix

### DIFF
--- a/arm/cores/wiring_time.c
+++ b/arm/cores/wiring_time.c
@@ -15,63 +15,55 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
-
 //****************************************************************************
 // @Project Includes
 //****************************************************************************
 #include "Arduino.h"
+#include "wiring_time.h"
 
 //****************************************************************************
 // @Macros
 //****************************************************************************
-/**< SysTick interval in seconds */
-#define SYSTIMER_TICK_PERIOD  (0.001F)
-
-/**< SysTick interval in microseconds */
-#define SYSTIMER_TICK_PERIOD_US  (1000U)
-
-/**< Maximum No of timer */
+/**< Maximum No of timer **/
 #define SYSTIMER_CFG_MAX_TMR  (8U)
 
-#if (UC_FAMILY == XMC4)
 #define SYSTIMER_PRIORITY  (4U)
-#elif (UC_FAMILY == XMC1)
-#define SYSTIMER_PRIORITY  (4U)
-#endif
 
 #define HW_TIMER_ADDITIONAL_CNT (1U)
 
 //****************************************************************************
 // @Defines
 //****************************************************************************
-#define TIMER_1mSec 1000              /*!< Millisecond to Microsecond ratio */
-#define TIMER_ISR_RATIO 1                              /*!< The ISR divider */
-#define TIMER_mSecTouSec_RATIO  \
-                (TIMER_1mSec/TIMER_ISR_RATIO)   /*!< mS to uS scaling factor*/
+/*!< Millisecond to Microsecond ratio */
+#define TIMER_1mSec 1000
+/*!< The ISR divider */
+#define TIMER_ISR_RATIO 1
+/*!< mS to uS scaling factor*/
+#define TIMER_mSecTouSec_RATIO  ( TIMER_1mSec / TIMER_ISR_RATIO )
 
 //****************************************************************************
 // @Typedefs
 //****************************************************************************
 /* SYSTIMER_OBJECT structure acts as the timer control block */
 typedef struct XMC_SYSTIMER_OBJECT
-{
-    struct XMC_SYSTIMER_OBJECT* next; /**< pointer to next timer control block */
-    struct XMC_SYSTIMER_OBJECT* prev; /**< Pointer to previous timer control block */
-    XMC_SYSTIMER_CALLBACK_t callback; /**< Callback function pointer */
-    XMC_SYSTIMER_MODE_t mode; /**< timer Type (single shot or periodic) */
-    XMC_SYSTIMER_STATE_t state; /**< timer state */
-    void* args; /**< Parameter to callback function */
-    uint32_t id; /**< timer ID */
-    uint32_t count; /**< timer count value */
-    uint32_t reload; /**< timer Reload count value */
-    bool delete_swtmr; /**< To delete the timer */
-} XMC_SYSTIMER_OBJECT_t;
+    {
+    struct XMC_SYSTIMER_OBJECT* next;   /**< pointer to next timer control block */
+    struct XMC_SYSTIMER_OBJECT* prev;   /**< Pointer to previous timer control block */
+    XMC_SYSTIMER_CALLBACK_t callback;   /**< Callback function pointer */
+    XMC_SYSTIMER_MODE_t mode;           /**< timer Type (single shot or periodic) */
+    XMC_SYSTIMER_STATE_t state;         /**< timer state */
+    void* args;                         /**< Parameter to callback function */
+    uint32_t id;                        /**< timer ID */
+    uint32_t count;                     /**< timer count value */
+    uint32_t reload;                    /**< timer Reload count value */
+    bool delete_swtmr;                  /**< To delete the timer */
+    } XMC_SYSTIMER_OBJECT_t;
 
 //****************************************************************************
 // @Global Variables
 //****************************************************************************
 /** Table which save timer control block. */
-XMC_SYSTIMER_OBJECT_t g_timer_tbl[SYSTIMER_CFG_MAX_TMR];
+XMC_SYSTIMER_OBJECT_t g_timer_tbl[ SYSTIMER_CFG_MAX_TMR ];
 
 /* The header of the timer Control list. */
 XMC_SYSTIMER_OBJECT_t* g_timer_list = NULL;
@@ -85,495 +77,427 @@ volatile uint16_t g_timer_entered_handler = 0u;
 /* SysTick counter */
 volatile uint32_t g_systick_count = 0U;
 
-__IO bool delay_timer_expired;
+// Should be volatile as updated in IRQ handler or callback from IRQ handler
+volatile __IO bool delay_timer_expired;
 
 //****************************************************************************
 // @Prototypes Of Local Functions
 //****************************************************************************
 
-/*
- * This function is called to insert a timer into the timer list.
- */
-static void XMC_SYSTIMER_lInsertTimerList(uint32_t tbl_index);
+/* This function is called to insert a timer into the timer list. */
+static void XMC_SYSTIMER_lInsertTimerList( uint32_t tbl_index );
 
-/*
- * This function is called to remove a timer from the timer list.
- */
-static void XMC_SYSTIMER_lRemoveTimerList(uint32_t tbl_index);
+/* This function is called to remove a timer from the timer list. */
+static void XMC_SYSTIMER_lRemoveTimerList( uint32_t tbl_index );
 
-/*
- * Handler function  called from SysTick event handler.
- */
-static void XMC_SYSTIMER_lTimerHandler(void);
+/* Handler function  called from SysTick event handler. */
+static void XMC_SYSTIMER_lTimerHandler( void );
 
-/*
- * SysTick handler which is the main interrupt service routine to service the
- * system timer's configured
- */
-void SysTick_Handler(void);
+/* SysTick handler which is the main interrupt service routine to service the
+ * system timer's configured */
+void SysTick_Handler( void );
 
-/*
- * cb function called after delay timer is expired
- */
-void delay_cb(void* Temp);
 
 //****************************************************************************
 // @Local Functions
 //****************************************************************************
-void wiring_time_init(void)
+void wiring_time_init( void )
 {
-    /* Initialize the header of the list */
-    g_timer_list = NULL;
-    /* Initialize SysTick timer */
-    SysTick_Config((uint32_t)(F_CPU * SYSTIMER_TICK_PERIOD));
+/* Initialize the header of the list */
+g_timer_list = NULL;
+/* Initialize SysTick timer for 1ms (1kHz) interval */
+SysTick_Config( (uint32_t)SYSTICK_MS );
 
-#if (UC_FAMILY == XMC4)
-    /* setting of First SW Timer period is always and subpriority value for XMC4000 devices */
-    NVIC_SetPriority(SysTick_IRQn, SYSTIMER_PRIORITY);
-#elif (UC_FAMILY == XMC1)
-    /* setting of priority value for XMC1000 devices */
-    NVIC_SetPriority(SysTick_IRQn, SYSTIMER_PRIORITY);
-#endif
-    g_timer_tracker = 0U;
+/* setting of First SW Timer period is always and sub-priority value for XMC4000 devices */
+/* setting of priority value for XMC1000 devices */
+NVIC_SetPriority( SysTick_IRQn, SYSTIMER_PRIORITY );
+g_timer_tracker = 0U;
 }
 
-uint32_t millis(void)
+
+void delay( uint32_t dwMs )
 {
-    return (XMC_SYSTIMER_GetTime() / 1000);
-}
+uint32_t TimerId;
 
-//TODO: not working properly as SYSTICK only runs on 1KHz
-uint32_t micros(void)
-{
-    return (XMC_SYSTIMER_GetTime());
-}
-
-void delay(uint32_t dwMs)
-{
-    uint32_t TimerId;
-
-    delay_timer_expired = FALSE;
-    /*
-     * This funcion uses SysTick Exception for controlling the timer list. Call back function
-     *   registered through this function will be called in SysTick exception when the timer is expired.
-     *   One shot timers are removed from the timer list, if it expires. To use
-     *   this SW timer again it has to be first deleted and then created again.
-     *
-     *  @param[in]  Period Timer period value in microseconds
-     *  @param[in]  TimerType Type of Timer(ONE_SHOT/PERIODIC)
-     *  @param[in]  TimerCallBack Call back function of the timer(No Macros are allowed)
-     *  @param[in]  pCallBackArgPtr Call back function parameter
-     */
-    TimerId = XMC_SYSTIMER_CreateTimer(dwMs * TIMER_mSecTouSec_RATIO, XMC_SYSTIMER_MODE_ONE_SHOT, delay_cb, NULL);
-    if (TimerId != 0)
-    {
-        //Timer is created successfully
-        XMC_SYSTIMER_StartTimer(TimerId);
-
-        // Wait until timer expires
-		do
-		{
-			yield();
-		}
-        while(!delay_timer_expired);
-
-        // Delete Timer since is One-Shot
-        XMC_SYSTIMER_DeleteTimer(TimerId);
-    }
-}
-
-void delay_cb(void* Temp)
-{
-    delay_timer_expired = TRUE;
-}
-
-/*
- * This function is called to insert a timer into the timer list.
+delay_timer_expired = FALSE;
+/* This function uses SysTick Exception for controlling the timer list. Call back function
+ * registered through this function will be called in SysTick exception when the timer is expired.
+ * One shot timers are removed from the timer list, if it expires. To use
+ * this SW timer again it has to be first deleted and then created again.
+ *
+ *  @param[in]  Period Timer period value in microseconds
+ *  @param[in]  TimerType Type of Timer(ONE_SHOT/PERIODIC)
+ *  @param[in]  TimerCallBack Call back function of the timer(No Macros are allowed)
+ *  @param[in]  pCallBackArgPtr Call back function parameter
+ *
+ * Special cases for callback action processing
+ *      args is NULL means a function with VOID parameter list called e.g function()
+ *      callback is NULL boolean delay_timer_expired is set to true
+ *
  */
-static void XMC_SYSTIMER_lInsertTimerList(uint32_t tbl_index)
+TimerId = XMC_SYSTIMER_CreateTimer( dwMs * TIMER_mSecTouSec_RATIO, XMC_SYSTIMER_MODE_ONE_SHOT,
+                                            NULL, NULL );
+if( TimerId != 0 )
+  {
+  //Timer is created successfully
+  XMC_SYSTIMER_StartTimer( TimerId );
+  // Wait until timer expires
+  do
+    yield( );
+  while( !delay_timer_expired );
+  // Delete Timer since is One-Shot
+  XMC_SYSTIMER_DeleteTimer( TimerId );
+  }
+}
+
+
+/* This function is called to insert a timer into the timer list. */
+static void XMC_SYSTIMER_lInsertTimerList( uint32_t tbl_index )
 {
-    XMC_SYSTIMER_OBJECT_t* object_ptr;
-    int32_t delta_ticks;
-    int32_t timer_count;
-    bool found_flag = false;
-    /* Get timer time */
-    timer_count = (int32_t)g_timer_tbl[tbl_index].count;
-    /* Check if Timer list is NULL */
-    if (NULL == g_timer_list)
+XMC_SYSTIMER_OBJECT_t* object_ptr;
+int32_t delta_ticks;
+int32_t timer_count;
+bool found_flag = false;
+/* Get timer time */
+timer_count = (int32_t)g_timer_tbl[ tbl_index ].count;
+/* Check if Timer list is NULL */
+if( NULL == g_timer_list )
+  /* Set this as first Timer */
+  g_timer_list = &g_timer_tbl[ tbl_index ];
+/* If not, find the correct place, and insert the specified timer */
+else
+  {
+  object_ptr = g_timer_list;
+  /* Get timer tick */
+  delta_ticks = timer_count;
+  /* Find correct place for inserting the timer */
+  while( ( NULL != object_ptr ) && ( false == found_flag ) )
     {
-        /* Set this as first Timer */
-        g_timer_list = &g_timer_tbl[tbl_index];
-    }
-    /* If not, find the correct place, and insert the specified timer */
-    else
-    {
-        object_ptr = g_timer_list;
-        /* Get timer tick */
-        delta_ticks = timer_count;
-        /* Find correct place for inserting the timer */
-        while ((NULL != object_ptr) && (false == found_flag))
+    /* Get timer Count Difference */
+    delta_ticks -= (int32_t)object_ptr->count;
+    /* Check for delta ticks < 0 */
+    if( delta_ticks <= 0)
+      {
+      /* Check If head item */
+      if( NULL != object_ptr->prev )
         {
-            /* Get timer Count Difference */
-            delta_ticks -= (int32_t)object_ptr->count;
-            /* Check for delta ticks < 0 */
-            if (delta_ticks <= 0)
-            {
-                /* Check If head item */
-                if (NULL != object_ptr->prev)
-                {
-                    /* If Insert to list */
-                    object_ptr->prev->next = &g_timer_tbl[tbl_index];
-                    g_timer_tbl[tbl_index].prev = object_ptr->prev;
-                    g_timer_tbl[tbl_index].next = object_ptr;
-                    object_ptr->prev = &g_timer_tbl[tbl_index];
-                }
-                else
-                {
-                    /* Set Timer as first item */
-                    g_timer_tbl[tbl_index].next = g_timer_list;
-                    g_timer_list->prev = &g_timer_tbl[tbl_index];
-                    g_timer_list = &g_timer_tbl[tbl_index];
-                }
-                g_timer_tbl[tbl_index].count = g_timer_tbl[tbl_index].next->count + (uint32_t)delta_ticks;
-                g_timer_tbl[tbl_index].next->count  -= g_timer_tbl[tbl_index].count;
-                found_flag = true;
-            }
-            /* Check for last item in list */
-            else
-            {
-                if ((delta_ticks > 0) && (NULL == object_ptr->next))
-                {
-                    /* Yes, insert into */
-                    g_timer_tbl[tbl_index].prev = object_ptr;
-                    object_ptr->next = &g_timer_tbl[tbl_index];
-                    g_timer_tbl[tbl_index].count = (uint32_t)delta_ticks;
-                    found_flag = true;
-                }
-            }
-            /* Get the next item in timer list */
-            object_ptr = object_ptr->next;
+        /* If Insert to list */
+        object_ptr->prev->next = &g_timer_tbl[ tbl_index ];
+        g_timer_tbl[ tbl_index ].prev = object_ptr->prev;
+        g_timer_tbl[ tbl_index ].next = object_ptr;
+        object_ptr->prev = &g_timer_tbl[ tbl_index ];
         }
+      else
+        {
+        /* Set Timer as first item */
+        g_timer_tbl[ tbl_index ].next = g_timer_list;
+        g_timer_list->prev = &g_timer_tbl[ tbl_index ];
+        g_timer_list = &g_timer_tbl[ tbl_index ];
+        }
+      g_timer_tbl[ tbl_index ].count = g_timer_tbl[ tbl_index ].next->count
+                                                    + (uint32_t)delta_ticks;
+      g_timer_tbl[ tbl_index ].next->count  -= g_timer_tbl[ tbl_index ].count;
+      found_flag = true;
+      }
+    /* Check for last item in list */
+    else
+      {
+      if( ( delta_ticks > 0 ) && ( NULL == object_ptr->next ) )
+        {
+        /* Yes, insert into */
+        g_timer_tbl[ tbl_index ].prev = object_ptr;
+        object_ptr->next = &g_timer_tbl[ tbl_index ];
+        g_timer_tbl[ tbl_index ].count = (uint32_t)delta_ticks;
+        found_flag = true;
+        }
+      }
+    /* Get the next item in timer list */
+    object_ptr = object_ptr->next;
     }
+  }
 }
 
-/*
- * This function is called to remove a timer from the timer list.
- */
-static void XMC_SYSTIMER_lRemoveTimerList(uint32_t tbl_index)
+
+/* This function is called to remove a timer from the timer list. */
+static void XMC_SYSTIMER_lRemoveTimerList( uint32_t tbl_index )
 {
-    XMC_SYSTIMER_OBJECT_t* object_ptr;
-    object_ptr = &g_timer_tbl[tbl_index];
-    /* Check whether only one timer available */
-    if ((NULL == object_ptr->prev) && (NULL == object_ptr->next ))
+XMC_SYSTIMER_OBJECT_t* object_ptr;
+object_ptr = &g_timer_tbl[ tbl_index ];
+/* Check whether only one timer available */
+if( ( NULL == object_ptr->prev ) && ( NULL == object_ptr->next ) )
+  /* set timer list as NULL */
+  g_timer_list = NULL;
+/* Check if the first item in timer list */
+else
+  if( NULL == object_ptr->prev )
     {
-        /* set timer list as NULL */
-        g_timer_list = NULL;
-    }
-    /* Check if the first item in timer list */
-    else if (NULL == object_ptr->prev)
-    {
-        /* Remove timer from list, and reset timer list */
-        g_timer_list  = object_ptr->next;
-        g_timer_list->prev = NULL;
-        g_timer_list->count += object_ptr->count;
-        object_ptr->next    = NULL;
+    /* Remove timer from list, and reset timer list */
+    g_timer_list  = object_ptr->next;
+    g_timer_list->prev = NULL;
+    g_timer_list->count += object_ptr->count;
+    object_ptr->next    = NULL;
     }
     /* Check if the last item in timer list */
-    else if (NULL == object_ptr->next)
+  else
     {
-        /* Remove timer from list */
-        object_ptr->prev->next = NULL;
-        object_ptr->prev = NULL;
-    }
+    if( NULL == object_ptr->next )
+      {
+      /* Remove timer from list */
+      object_ptr->prev->next = NULL;
+      object_ptr->prev = NULL;
+      }
     else
-    {
-        /* Remove timer from list */
-        object_ptr->prev->next  =  object_ptr->next;
-        object_ptr->next->prev  =  object_ptr->prev;
-        object_ptr->next->count += object_ptr->count;
-        object_ptr->next = NULL;
-        object_ptr->prev = NULL;
+      {
+      /* Remove timer from list */
+      object_ptr->prev->next  =  object_ptr->next;
+      object_ptr->next->prev  =  object_ptr->prev;
+      object_ptr->next->count += object_ptr->count;
+      object_ptr->next = NULL;
+      object_ptr->prev = NULL;
+      }
     }
 }
 
-/*
- * Handler function called from SysTick event handler.
- */
-static void XMC_SYSTIMER_lTimerHandler(void)
+
+/* Handler function called from SysTick event handler. */
+static void XMC_SYSTIMER_lTimerHandler( void )
 {
-    XMC_SYSTIMER_OBJECT_t* object_ptr;
-    /* Handler entered */
-    g_timer_entered_handler++;
+XMC_SYSTIMER_OBJECT_t* object_ptr;
+int found;
+
+/* Handler entered */
+g_timer_entered_handler++;
+/* Get first item of timer list */
+object_ptr = g_timer_list;
+while( ( NULL != object_ptr ) && ( 0U == object_ptr->count ) )
+    {
+    found = 0;
+    if( true == object_ptr->delete_swtmr )
+      {
+      found = 1;
+      /* Set timer status as SYSTIMER_STATE_NOT_INITIALIZED */
+      object_ptr->state = XMC_SYSTIMER_STATE_NOT_INITIALIZED;
+      /* Release resource which are hold by this timer */
+      g_timer_tracker &= ~( 1U << object_ptr->id );
+      }
+    /* Check whether timer is a one shot timer */
+    else
+      if( XMC_SYSTIMER_MODE_ONE_SHOT == object_ptr->mode )
+        {
+        if( XMC_SYSTIMER_STATE_RUNNING == object_ptr->state )
+          {
+          found = 2;
+          /* Set timer status as SYSTIMER_STATE_STOPPED */
+          object_ptr->state = XMC_SYSTIMER_STATE_STOPPED;
+          }
+        }
+    /* Check whether timer is periodic timer */
+      else
+        if( XMC_SYSTIMER_MODE_PERIODIC == object_ptr->mode )
+          {
+          if( XMC_SYSTIMER_STATE_RUNNING == object_ptr->state )
+            {
+            found = 3;
+            /* Reset timer tick */
+            object_ptr->count = object_ptr->reload;
+            }
+          }
+        else
+          break;
+    // process common aspects having found a match
+    if( found )
+      {
+      /* Yes, remove this timer from timer list */
+      XMC_SYSTIMER_lRemoveTimerList( (uint32_t)object_ptr->id );
+      if( found > 1 )
+        {
+        /* Call timer callback function */
+        if( object_ptr->callback == NULL )
+          delay_timer_expired = TRUE;         // Special case of NULL callback function
+        else
+          if( object_ptr->args != NULL )
+            ( object_ptr->callback )( object_ptr->args );
+          else                    // Special case NULL arguments address
+            ( (XMC_SYSTIMER_CALLBACK_tn)object_ptr->callback )(  );
+        if( found == 3 )      // Reinsert into timer list
+          XMC_SYSTIMER_lInsertTimerList( (uint32_t)object_ptr->id );
+        }
+      }
     /* Get first item of timer list */
     object_ptr = g_timer_list;
-    while ((NULL != object_ptr) && (0U == object_ptr->count))
-    {
-        if (true == object_ptr->delete_swtmr)
-        {
-            /* Yes, remove this timer from timer list */
-            XMC_SYSTIMER_lRemoveTimerList((uint32_t)object_ptr->id);
-            /* Set timer status as SYSTIMER_STATE_NOT_INITIALIZED */
-            object_ptr->state = XMC_SYSTIMER_STATE_NOT_INITIALIZED;
-            /* Release resource which are hold by this timer */
-            g_timer_tracker &= ~(1U << object_ptr->id);
-        }
-        /* Check whether timer is a one shot timer */
-        else if (XMC_SYSTIMER_MODE_ONE_SHOT == object_ptr->mode)
-        {
-            if (XMC_SYSTIMER_STATE_RUNNING == object_ptr->state)
-            {
-                /* Yes, remove this timer from timer list */
-                XMC_SYSTIMER_lRemoveTimerList((uint32_t)object_ptr->id);
-                /* Set timer status as SYSTIMER_STATE_STOPPED */
-                object_ptr->state = XMC_SYSTIMER_STATE_STOPPED;
-                /* Call timer callback function */
-                (object_ptr->callback)(object_ptr->args);
-            }
-        }
-        /* Check whether timer is periodic timer */
-        else if (XMC_SYSTIMER_MODE_PERIODIC == object_ptr->mode)
-        {
-            if (XMC_SYSTIMER_STATE_RUNNING == object_ptr->state)
-            {
-                /* Yes, remove this timer from timer list */
-                XMC_SYSTIMER_lRemoveTimerList((uint32_t)object_ptr->id);
-                /* Reset timer tick */
-                object_ptr->count = object_ptr->reload;
-                /* Insert timer into timer list */
-                XMC_SYSTIMER_lInsertTimerList((uint32_t)object_ptr->id);
-                /* Call timer callback function */
-                (object_ptr->callback)(object_ptr->args);
-            }
-        }
-        else
-        {
-            break;
-        }
-        /* Get first item of timer list */
-        object_ptr = g_timer_list;
     }
 }
 
-/*
- *  SysTick Event Handler.
- */
-void SysTick_Handler(void)
+
+/* SysTick Event Handler. */
+void SysTick_Handler( void )
 {
-    XMC_SYSTIMER_OBJECT_t* object_ptr;
-    object_ptr = g_timer_list;
-    g_systick_count++;
+XMC_SYSTIMER_OBJECT_t* object_ptr;
+object_ptr = g_timer_list;
+g_systick_count++;
 
-    if (NULL != object_ptr)
+if( NULL != object_ptr )
+  {
+  if( object_ptr->count > 1UL )
+    object_ptr->count--;
+  else
     {
-        if (object_ptr->count > 1UL)
-        {
-            object_ptr->count--;
-        }
-        else
-        {
-            object_ptr->count = 0U;
-            // do not call handler, when still running
-            if(g_timer_entered_handler == 0u)
-            {
-            	//g_timer_entered_handler++;
-            	XMC_SYSTIMER_lTimerHandler();
-            	g_timer_entered_handler--;
-            }
-        }
+    object_ptr->count = 0U;
+    // do not call handler, when still running
+    if( g_timer_entered_handler == 0u )
+      {
+      //g_timer_entered_handler++;
+      XMC_SYSTIMER_lTimerHandler();
+      g_timer_entered_handler--;
+      }
     }
+  }
 }
+
 
 /** @ingroup Simple_System_Timer_App PublicFunc
  * @{
  */
-
-/*
- *  API for creating a new software Timer instance.
- */
-uint32_t XMC_SYSTIMER_CreateTimer
-(
-    uint32_t period,
-    XMC_SYSTIMER_MODE_t mode,
-    XMC_SYSTIMER_CALLBACK_t callback,
-    void*  args
-)
+/* API for creating a new software Timer instance. */
+uint32_t XMC_SYSTIMER_CreateTimer( uint32_t period, XMC_SYSTIMER_MODE_t mode,
+                                        XMC_SYSTIMER_CALLBACK_t callback, void* args )
 {
-    uint32_t id = 0U;
-    uint32_t count = 0U;
-    uint32_t period_ratio = 0U;
+uint32_t id = 0U;
+uint32_t count = 0U;
+uint32_t period_ratio = 0U;
 
-    if (period < SYSTIMER_TICK_PERIOD_US)
+if( period < SYSTIMER_TICK_PERIOD_US )
+  id = 0U;
+else
+  {
+  for( count = 0U; count < SYSTIMER_CFG_MAX_TMR; count++ )
     {
-        id = 0U;
+    /* Check for free timer ID */
+    if( 0U == ( g_timer_tracker & ( 1U << count ) ) )
+      {
+      /* If yes, assign ID to this timer */
+      g_timer_tracker |= ( 1U << count );
+      /* Initialize the timer as per input values */
+      g_timer_tbl[ count ].id       = count;
+      g_timer_tbl[ count ].mode     = mode;
+      g_timer_tbl[ count ].state    = XMC_SYSTIMER_STATE_STOPPED;
+      period_ratio = (uint32_t)( period / SYSTIMER_TICK_PERIOD_US );
+      g_timer_tbl[ count ].count    = ( period_ratio + HW_TIMER_ADDITIONAL_CNT );
+      g_timer_tbl[ count ].reload   = period_ratio;
+      g_timer_tbl[ count ].callback = callback;
+      g_timer_tbl[ count ].args     = args;
+      g_timer_tbl[ count ].prev     = NULL;
+      g_timer_tbl[ count ].next     = NULL;
+      id = count + 1U;
+      break;
+      }
     }
-    else
-    {
-        for (count = 0U; count < SYSTIMER_CFG_MAX_TMR; count++)
-        {
-            /* Check for free timer ID */
-            if (0U == (g_timer_tracker & (1U << count)))
-            {
-                /* If yes, assign ID to this timer */
-                g_timer_tracker |= (1U << count);
-                /* Initialize the timer as per input values */
-                g_timer_tbl[count].id     = count;
-                g_timer_tbl[count].mode   = mode;
-                g_timer_tbl[count].state  = XMC_SYSTIMER_STATE_STOPPED;
-                period_ratio = (uint32_t)(period / SYSTIMER_TICK_PERIOD_US);
-                g_timer_tbl[count].count  = (period_ratio + HW_TIMER_ADDITIONAL_CNT);
-                g_timer_tbl[count].reload  = period_ratio;
-                g_timer_tbl[count].callback = callback;
-                g_timer_tbl[count].args = args;
-                g_timer_tbl[count].prev   = NULL;
-                g_timer_tbl[count].next   = NULL;
-                id = count + 1U;
-                break;
-            }
-        }
-
-    }
-
-    return (id);
+  }
+return ( id );
 }
 
-/*
- *  API to start the software timer.
- */
-XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_StartTimer(uint32_t id)
+
+/* API to start the software timer. */
+XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_StartTimer( uint32_t id )
 {
-    XMC_SYSTIMER_STATUS_t status;
-    status = XMC_SYSTIMER_STATUS_FAILURE;
+XMC_SYSTIMER_STATUS_t status;
+status = XMC_SYSTIMER_STATUS_FAILURE;
 
-    /* Check if timer is running */
-    if (XMC_SYSTIMER_STATE_STOPPED == g_timer_tbl[id - 1U].state)
-    {
-        g_timer_tbl[id - 1U].count = (g_timer_tbl[id - 1U].reload + HW_TIMER_ADDITIONAL_CNT);
-        /* set timer status as XMC_SYSTIMER_STATE_RUNNING */
-        g_timer_tbl[id - 1U].state = XMC_SYSTIMER_STATE_RUNNING;
-        /* Insert this timer into timer list */
-        XMC_SYSTIMER_lInsertTimerList((id - 1U));
-        status = XMC_SYSTIMER_STATUS_SUCCESS;
-    }
-
-    return (status);
+/* Check if timer is running */
+id -= 1U;
+if( XMC_SYSTIMER_STATE_STOPPED == g_timer_tbl[ id ].state )
+  {
+  g_timer_tbl[ id ].count = g_timer_tbl[ id ].reload + HW_TIMER_ADDITIONAL_CNT;
+  /* set timer status as XMC_SYSTIMER_STATE_RUNNING */
+  g_timer_tbl[ id ].state = XMC_SYSTIMER_STATE_RUNNING;
+  /* Insert this timer into timer list */
+  XMC_SYSTIMER_lInsertTimerList( id );
+  status = XMC_SYSTIMER_STATUS_SUCCESS;
+  }
+return ( status );
 }
 
-/*
- *  API to stop the software timer.
- */
-XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_StopTimer(uint32_t id)
+
+/* API to stop the software timer.  */
+XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_StopTimer( uint32_t id )
 {
-    XMC_SYSTIMER_STATUS_t status;
-    status = XMC_SYSTIMER_STATUS_SUCCESS;
+XMC_SYSTIMER_STATUS_t status;
+status = XMC_SYSTIMER_STATUS_SUCCESS;
 
-    if (XMC_SYSTIMER_STATE_NOT_INITIALIZED == g_timer_tbl[id - 1U].state)
+id -= 1U;
+if( XMC_SYSTIMER_STATE_NOT_INITIALIZED == g_timer_tbl[ id ].state )
+  status = XMC_SYSTIMER_STATUS_FAILURE;
+else
+  {
+  /* Check whether Timer is in Stop state */
+  if( XMC_SYSTIMER_STATE_RUNNING == g_timer_tbl[ id ].state )
     {
-        status = XMC_SYSTIMER_STATUS_FAILURE;
+    /* Set timer status as SYSTIMER_STATE_STOPPED */
+    g_timer_tbl[ id ].state = XMC_SYSTIMER_STATE_STOPPED;
+
+    /* remove Timer from node list */
+    XMC_SYSTIMER_lRemoveTimerList( id );
     }
-    else
-    {
-        /* Check whether Timer is in Stop state */
-        if (XMC_SYSTIMER_STATE_RUNNING == g_timer_tbl[id - 1U].state)
-        {
-            /* Set timer status as SYSTIMER_STATE_STOPPED */
-            g_timer_tbl[id - 1U].state = XMC_SYSTIMER_STATE_STOPPED;
-
-            /* remove Timer from node list */
-            XMC_SYSTIMER_lRemoveTimerList(id - 1U);
-
-        }
-    }
-
-    return (status);
+  }
+return ( status );
 }
 
-/*
- *  API to reinitialize the time interval and to start the timer.
- */
-XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_RestartTimer(uint32_t id, uint32_t microsec)
+
+/* API to reinitialize the time interval and to start the timer. */
+XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_RestartTimer( uint32_t id, uint32_t microsec )
 {
-    uint32_t period_ratio = 0U;
-    XMC_SYSTIMER_STATUS_t status;
-    status = XMC_SYSTIMER_STATUS_SUCCESS;
+uint32_t period_ratio = 0U;
+XMC_SYSTIMER_STATUS_t status;
+status = XMC_SYSTIMER_STATUS_SUCCESS;
 
-    if (XMC_SYSTIMER_STATE_NOT_INITIALIZED == g_timer_tbl[id - 1U].state)
+if( XMC_SYSTIMER_STATE_NOT_INITIALIZED == g_timer_tbl[ id - 1U ].state )
+  status = XMC_SYSTIMER_STATUS_FAILURE;
+else
+  {
+  /* check whether timer is in run state */
+  if( XMC_SYSTIMER_STATE_STOPPED != g_timer_tbl[ id - 1U ].state )
     {
-        status = XMC_SYSTIMER_STATUS_FAILURE;
+    /* Stop the timer */
+    status = XMC_SYSTIMER_StopTimer( id );
     }
-    else
+  if( XMC_SYSTIMER_STATUS_SUCCESS == status )
     {
-        /* check whether timer is in run state */
-        if ( XMC_SYSTIMER_STATE_STOPPED != g_timer_tbl[id - 1U].state)
-        {
-            /* Stop the timer */
-            status = XMC_SYSTIMER_StopTimer(id);
-        }
-        if (XMC_SYSTIMER_STATUS_SUCCESS == status)
-        {
-            period_ratio = (uint32_t)(microsec / SYSTIMER_TICK_PERIOD_US);
-            g_timer_tbl[id - 1U].reload = period_ratio;
-            /* Start the timer */
-            status = XMC_SYSTIMER_StartTimer(id);
-        }
+    period_ratio = (uint32_t)( microsec / SYSTIMER_TICK_PERIOD_US );
+    g_timer_tbl[ id - 1U ].reload = period_ratio;
+    /* Start the timer */
+    status = XMC_SYSTIMER_StartTimer( id );
     }
-
-    return (status);
+  }
+return ( status );
 }
 
-/*
- *  Function to delete the Timer instance.
- */
-XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_DeleteTimer(uint32_t id)
-{
-    XMC_SYSTIMER_STATUS_t status;
-    status = XMC_SYSTIMER_STATUS_SUCCESS;
 
-    /* Check whether Timer is in delete state */
-    if (XMC_SYSTIMER_STATE_NOT_INITIALIZED == g_timer_tbl[id - 1U].state)
+/* Function to delete the Timer instance. */
+XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_DeleteTimer( uint32_t id )
+{
+XMC_SYSTIMER_STATUS_t status;
+status = XMC_SYSTIMER_STATUS_SUCCESS;
+
+/* Check whether Timer is in delete state first change id */
+id -= 1U;
+if( XMC_SYSTIMER_STATE_NOT_INITIALIZED == g_timer_tbl[ id ].state )
+  status = XMC_SYSTIMER_STATUS_FAILURE;
+else
+  {
+  if( XMC_SYSTIMER_STATE_STOPPED == g_timer_tbl[ id ].state )
     {
-        status = XMC_SYSTIMER_STATUS_FAILURE;
+    /* Set timer status as SYSTIMER_STATE_NOT_INITIALIZED */
+    g_timer_tbl[ id ].state = XMC_SYSTIMER_STATE_NOT_INITIALIZED;
+    /* Release resource which are hold by this timer */
+    g_timer_tracker &= ~( 1U << id );
     }
-    else
+  else
     {
-        if (XMC_SYSTIMER_STATE_STOPPED == g_timer_tbl[id - 1U].state)
-        {
-            /* Set timer status as SYSTIMER_STATE_NOT_INITIALIZED */
-            g_timer_tbl[id - 1U].state = XMC_SYSTIMER_STATE_NOT_INITIALIZED;
-            /* Release resource which are hold by this timer */
-            g_timer_tracker &= ~(1U << (id - 1U));
-        }
-        else
-        {
-            /* Yes, remove this timer from timer list during ISR execution */
-            g_timer_tbl[id - 1U].delete_swtmr = true;
-        }
+    /* Yes, remove this timer from timer list during ISR execution */
+    g_timer_tbl[ id ].delete_swtmr = true;
     }
-
-    return (status);
-}
-
-/*
- *  API to get the current SysTick time in microsecond.
- */
-uint32_t XMC_SYSTIMER_GetTime(void)
-{
-    return (g_systick_count * SYSTIMER_TICK_PERIOD_US);
-}
-
-/*
- *  API to get the SysTick count.
- */
-uint32_t XMC_SYSTIMER_GetTickCount(void)
-{
-    return (g_systick_count);
-}
-
-/*
- *  API to get the current state of software timer.
- */
-XMC_SYSTIMER_STATE_t XMC_SYSTIMER_GetTimerState(uint32_t id)
-{
-    return (g_timer_tbl[id - 1U].state);
+  }
+return ( status );
 }
 
 //****************************************************************************

--- a/arm/cores/wiring_time.h
+++ b/arm/cores/wiring_time.h
@@ -25,188 +25,231 @@ extern "C" {
 //****************************************************************************
 // @Defines
 //****************************************************************************
+/**< SysTick interval in microseconds */
+#define SYSTIMER_TICK_PERIOD_US  (1000U)
+/**< value for Systick counts per ms **/
+#define SYSTICK_MS  ( F_CPU / SYSTIMER_TICK_PERIOD_US )
+/**< value for Systick counts per us **/
+#define SYSTICK_US  ( SYSTICK_MS / SYSTIMER_TICK_PERIOD_US )
+
 #if ((UC_FAMILY == XMC4) && (F_CPU == 144000000U))
-
-#define NOPS_FOR_USEC()    asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop");asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop")
-							
+// 142 NOPS
+#define NOPS_FOR_USEC() asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+                        asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+                        asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+                        asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+                        asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop")
 #elif ((UC_FAMILY == XMC1) && (F_CPU == 32000000U))
-
-#define NOPS_FOR_USEC()    asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop")
+// 16 NOPS
+#define NOPS_FOR_USEC() asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop")
 #else
-#error wiring_time: NOPS_FOR_USEC not defined 
+#error wiring_time: NOPS_FOR_USEC not defined
 #endif
 
 //****************************************************************************
 // @Typedefs
 //****************************************************************************
-    typedef void (*XMC_SYSTIMER_CALLBACK_t)(void* args);
+typedef void ( *XMC_SYSTIMER_CALLBACK_t )( void* args );
+// For casting previous to empty parameter list function call
+typedef void ( *XMC_SYSTIMER_CALLBACK_tn )( );
 
-    typedef enum XMC_SYSTIMER_STATUS
+typedef enum XMC_SYSTIMER_STATUS
     {
-        XMC_SYSTIMER_STATUS_SUCCESS = 0U, /**< Status Success if initialization is successful */
-        XMC_SYSTIMER_STATUS_FAILURE  /**< Status Failure if initialization is failed */
+    XMC_SYSTIMER_STATUS_SUCCESS = 0U, /**< Status Success if initialization is successful */
+    XMC_SYSTIMER_STATUS_FAILURE         /**< Status Failure if initialization is failed */
     } XMC_SYSTIMER_STATUS_t;
 
-    typedef enum XMC_SYSTIMER_MODE
+typedef enum XMC_SYSTIMER_MODE
     {
-        XMC_SYSTIMER_MODE_ONE_SHOT = 0U, /**< timer type is one shot */
-        XMC_SYSTIMER_MODE_PERIODIC /**< timer type is periodic */
+    XMC_SYSTIMER_MODE_ONE_SHOT = 0U, /**< timer type is one shot */
+    XMC_SYSTIMER_MODE_PERIODIC      /**< timer type is periodic */
     } XMC_SYSTIMER_MODE_t;
 
-    typedef enum XMC_SYSTIMER_STATE
+typedef enum XMC_SYSTIMER_STATE
     {
-        XMC_SYSTIMER_STATE_NOT_INITIALIZED = 0U, /**< The timer is in uninitialized state */
-        XMC_SYSTIMER_STATE_RUNNING, /**< The timer is in running state */
-        XMC_SYSTIMER_STATE_STOPPED /**< The timer is in stop state */
+    XMC_SYSTIMER_STATE_NOT_INITIALIZED = 0U, /**< The timer is in uninitialized state */
+    XMC_SYSTIMER_STATE_RUNNING,             /**< The timer is in running state */
+    XMC_SYSTIMER_STATE_STOPPED              /**< The timer is in stop state */
     } XMC_SYSTIMER_STATE_t;
+
+/* SysTick counter */
+extern volatile uint32_t g_systick_count;
 
 //****************************************************************************
 // @External Prototypes
 //****************************************************************************
+/*
+ * \brief Initialize the time module.
+ */
+extern void wiring_time_init( void );
 
-    /*
-     * \brief Initialize the time module.
-     */
-    extern void wiring_time_init(void);
 
-    /*
-     * \brief Returns the number of milliseconds since the Arduino board began running the current program.
-     *
-     * This number will overflow (go back to zero), after approximately 50 days.
-     *
-     * \return Number of milliseconds since the program started (uint32_t)
-     */
-    extern uint32_t millis(void) ;
+/*
+ * \brief Returns the number of milliseconds since the Arduino board began running the current program.
+ *
+ * This number will overflow (go back to zero), after approximately 50 days.
+ *
+ * \return Number of milliseconds since the program started (uint32_t)
+ */
+static inline uint32_t  millis( void ) __attribute__(( always_inline ));
+static inline uint32_t  millis( void )
+{
+return ( g_systick_count );
+}
 
-    /*
-     * \brief Returns the number of microseconds since the Arduino board began running the current program.
-     *
-     * This number will overflow (go back to zero), after approximately 70 minutes. On 16 MHz Arduino boards
-     * (e.g. Duemilanove and Nano), this function has a resolution of four microseconds (i.e. the value returned is
-     * always a multiple of four). On 8 MHz Arduino boards (e.g. the LilyPad), this function has a resolution
-     * of eight microseconds.
-     *
-     * \note There are 1,000 microseconds in a millisecond and 1,000,000 microseconds in a second.
-     */
-    extern uint32_t micros(void) ;
 
-    /*
-     * \brief Pauses the program for the amount of time (in miliseconds) specified as parameter.
-     * (There are 1000 milliseconds in a second.)
-     *
-     * \param dwMs the number of milliseconds to pause (uint32_t)
-     */
-    extern void delay(uint32_t dwMs) ;
+/*
+ * \brief Returns the number of microseconds since the Arduino board began running the current program.
+ *
+ * This number will overflow (go back to zero), after approximately 70 minutes. On 16 MHz Arduino
+ * boards (e.g. Duemilanove and Nano), this function has a resolution of four microseconds (i.e.
+ * the value returned is always a multiple of four). On 8 MHz Arduino boards (e.g. the LilyPad), this
+ * function has a resolution of eight microseconds.
+ *
+ * \note There are 1,000 microseconds in a millisecond and 1,000,000 microseconds in a second.
 
-    /*
-     * \brief Pauses the program for the amount of time (in microseconds) specified as parameter.
-     *
-     * \param dwUs the number of microseconds to pause (uint32_t)
-     */
-    static inline void delayMicroseconds(uint32_t) __attribute__((always_inline));
-    static inline void delayMicroseconds(uint32_t usec)
+   get micro seconds since power up 
+   Read milli seconds (in microseconds) and convert Systick counter to microseconds to add to it 
+   remember SysTick->VAL counts DOWN to zero */
+static inline uint32_t  micros( void ) __attribute__(( always_inline ));
+static inline uint32_t  micros( void )
+{
+return ( ( g_systick_count * SYSTIMER_TICK_PERIOD_US )
+            + ( ( ( SYSTICK_MS - SysTick->VAL ) / SYSTICK_US ) ) );
+}
+
+
+/*
+ * \brief Pauses the program for the amount of time (in milliseconds) specified as parameter.
+ * (There are 1000 milliseconds in a second.)
+ *
+ * \param dwMs the number of milliseconds to pause (uint32_t)
+ */
+extern void delay( uint32_t dwMs );
+
+/*
+ * \brief Pauses the program for the amount of time (in microseconds) specified as parameter.
+ *
+ * \param dwUs the number of microseconds to pause (uint32_t)
+ */
+static inline void delayMicroseconds( uint32_t ) __attribute__(( always_inline ));
+static inline void delayMicroseconds( uint32_t usec )
+{
+if( usec == 0 )
+  return;
+else
     {
+    uint32_t number_of_cycles = usec;
 
-        if (usec == 0)
+    noInterrupts( );
+    // NOP loop to generate delay
+    while( number_of_cycles )
         {
-            return;
+        NOPS_FOR_USEC( );
+        number_of_cycles--;
         }
-        else
-        {
-            uint32_t number_of_cycles = usec;
-			
-			noInterrupts();
-            // NOP loop to gnerate delay
-            while (number_of_cycles)
-            {
-				NOPS_FOR_USEC();
-                number_of_cycles--;
-            }
-			interrupts();
-        }
+    interrupts( );
     }
-    /*
-     * @brief Creates a new software timer.
-     * @param period  timer period value in microseconds. Range: (SYSTIMER_TICK_PERIOD_US) to pow(2,32).
-     * @param mode  Mode of timer(ONE_SHOT/PERIODIC). Refer @ref XMC_SYSTIMER_MODE_t for details.
-     * @param callback  Call back function of the timer(No Macros are allowed).
-     * @param args  Call back function parameter.
-     */
-    uint32_t XMC_SYSTIMER_CreateTimer
-    (
-        uint32_t period,
-        XMC_SYSTIMER_MODE_t mode,
-        XMC_SYSTIMER_CALLBACK_t callback,
-        void*  args
-    );
+}
 
-    /*
-     * @brief Starts the software timer.
-     * @param id  timer ID obtained from SYSTIMER_CreateTimer. Range : 1 to 16
-     * @return XMC_SYSTIMER_STATUS_t APP status. Refer @ref XMC_SYSTIMER_STATUS_t for details.
-     */
-    XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_StartTimer(uint32_t id);
 
-    /*
-     * @brief Stops the software timer.
-     * @param id  timer ID obtained from SYSTIMER_CreateTimer. Range : 1 to 16
-     * @return XMC_SYSTIMER_STATUS_t APP status. Refer @ref XMC_SYSTIMER_STATUS_t for details.
-     */
-    XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_StopTimer(uint32_t id);
+/*
+ * @brief Creates a new software timer.
+ * @param period  timer period value in microseconds. Range: (SYSTIMER_TICK_PERIOD_US) to pow(2,32).
+ * @param mode  Mode of timer(ONE_SHOT/PERIODIC). Refer @ref XMC_SYSTIMER_MODE_t for details.
+ * @param callback  Call back function of the timer (No Macros are allowed).
+ * @param args  Call back function parameter.
+ *
+ * Normally calls function callback( *args )
+ *
+ * Special cases for callback action processing
+ *      args is NULL means a function with VOID parameter list called e.g callback()
+ *      callback is NULL boolean delay_timer_expired is set to true
+ *
+ * This reduces warnings and also stops accidental callback of NULL causing leap to never never land
+ */
+uint32_t XMC_SYSTIMER_CreateTimer( uint32_t period, XMC_SYSTIMER_MODE_t mode,
+                                        XMC_SYSTIMER_CALLBACK_t callback, void*  args );
 
-    /*
-     * @brief Function to modify the time interval and restart the timer for the new time interval.<br>
-     * @param id ID of already created system timer. Range : 1 to 16
-     * @param microsec new time interval. Range: (SYSTIMER_TICK_PERIOD_US) to pow(2,32).
-     * @return XMC_SYSTIMER_STATUS_t APP status. Refer @ref XMC_SYSTIMER_STATUS_t for details.
-     */
-    XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_RestartTimer(uint32_t id, uint32_t microsec);
+/*
+ * @brief Starts the software timer.
+ * @param id  timer ID obtained from SYSTIMER_CreateTimer. Range : 1 to 16
+ * @return XMC_SYSTIMER_STATUS_t APP status. Refer @ref XMC_SYSTIMER_STATUS_t for details.
+ */
+XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_StartTimer( uint32_t id );
 
-    /*
-     * @brief Deletes the software timer from the timer list.
-     * @param id  timer ID obtained from SYSTIMER_CreateTimer. Range : 1 to 16
-     * @return XMC_SYSTIMER_STATUS_t APP status. Refer @ref XMC_SYSTIMER_STATUS_t for details.
-     */
-    XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_DeleteTimer(uint32_t id);
+/*
+ * @brief Stops the software timer.
+ * @param id  timer ID obtained from SYSTIMER_CreateTimer. Range : 1 to 16
+ * @return XMC_SYSTIMER_STATUS_t APP status. Refer @ref XMC_SYSTIMER_STATUS_t for details.
+ */
+XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_StopTimer( uint32_t id );
 
-    /*
-     * @brief Gives the current hardware SysTick time in microsecond since start of hardware SysTick timer.
-     * @return  uint32_t  returns current SysTick time in microsecond. Range: (SYSTIMER_TICK_PERIOD_US) to pow(2,32).
-     */
-    uint32_t XMC_SYSTIMER_GetTime(void);
+/*
+ * @brief Function to modify the time interval and restart the timer for the new time interval.<br>
+ * @param id ID of already created system timer. Range : 1 to 16
+ * @param microsec new time interval. Range: (SYSTIMER_TICK_PERIOD_US) to pow(2,32).
+ * @return XMC_SYSTIMER_STATUS_t APP status. Refer @ref XMC_SYSTIMER_STATUS_t for details.
+ */
+XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_RestartTimer( uint32_t id, uint32_t microsec );
 
-    /*
-     * @brief Gives the SysTick count.
-     * @return  uint32_t  returns SysTick count. Range: 0 to pow(2,32).
-     */
-    uint32_t XMC_SYSTIMER_GetTickCount(void);
-
-    /*
-     * @brief Gives the current state of software timer.
-     * @param id  timer ID obtained from SYSTIMER_CreateTimer. Range : 1 to 16
-     * @return XMC_SYSTIMER_STATE_t Software timer state. Refer @ref XMC_SYSTIMER_STATE_t for details.
-     */
-    XMC_SYSTIMER_STATE_t XMC_SYSTIMER_GetTimerState(uint32_t id);
+/*
+ * @brief Deletes the software timer from the timer list.
+ * @param id  timer ID obtained from SYSTIMER_CreateTimer. Range : 1 to 16
+ * @return XMC_SYSTIMER_STATUS_t APP status. Refer @ref XMC_SYSTIMER_STATUS_t for details.
+ */
+XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_DeleteTimer( uint32_t id );
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif /* WIRING_TIME_H_ */

--- a/arm/cores/xmc_lib/XMCLib/inc/xmc_vadc.h
+++ b/arm/cores/xmc_lib/XMCLib/inc/xmc_vadc.h
@@ -1490,6 +1490,8 @@ __STATIC_INLINE void XMC_VADC_GLOBAL_ClockInit(XMC_VADC_GLOBAL_t *const global_p
 }
 #endif
 
+#if 0
+// Function not used in XMC-for-Arduino and probably not tested
 /**
  *
  * @param global_ptr Constant pointer to the VADC module.
@@ -1512,6 +1514,7 @@ __STATIC_INLINE void XMC_VADC_GLOBAL_ClockInit(XMC_VADC_GLOBAL_t *const global_p
 
 void XMC_VADC_GLOBAL_InputClassInit(XMC_VADC_GLOBAL_t *const global_ptr, const XMC_VADC_GLOBAL_CLASS_t config,
                                           const XMC_VADC_GROUP_CONV_t conv_type, const uint32_t set_num);
+#endif
 
 /**
  *

--- a/arm/cores/xmc_lib/XMCLib/src/xmc_vadc.c
+++ b/arm/cores/xmc_lib/XMCLib/src/xmc_vadc.c
@@ -228,6 +228,7 @@ void XMC_VADC_GLOBAL_Init(XMC_VADC_GLOBAL_t *const global_ptr, const XMC_VADC_GL
 
 }
 
+#if 0
 /* API to Set the Global IClass registers*/
 void XMC_VADC_GLOBAL_InputClassInit(XMC_VADC_GLOBAL_t *const global_ptr, const XMC_VADC_GLOBAL_CLASS_t config,
                                           const XMC_VADC_GROUP_CONV_t conv_type, const uint32_t set_num)
@@ -251,6 +252,7 @@ void XMC_VADC_GLOBAL_InputClassInit(XMC_VADC_GLOBAL_t *const global_ptr, const X
   }
 #endif
 }
+#endif
 
 /* API to enable startup calibration feature */
 void XMC_VADC_GLOBAL_StartupCalibration(XMC_VADC_GLOBAL_t *const global_ptr)
@@ -287,6 +289,7 @@ void XMC_VADC_GLOBAL_StartupCalibration(XMC_VADC_GLOBAL_t *const global_ptr)
   }
 #endif
 }
+
 
 /* API to set boudaries for result of conversion. Should the boundaries be violated, interrupts are generated */
 #if (XMC_VADC_BOUNDARY_AVAILABLE == 1U)


### PR DESCRIPTION
This fixes compiler warnings  for XMC1xxx and only leaves USB compiler warnings for XMC4xxxx 

Removes wasteful functions inlines simple millis() and micros() to reduce overhead

Simplifies and makes more readable many functions

XMC_SYSTIMER_lTimerHandler function has simplification to reduce size and adds methods of callback
```
*
 * Special cases for callback action processing
 *      args is NULL means a function with VOID parameter list called e.g function()
 *      callback is NULL boolean delay_timer_expired is set to true
 *
```
Reduces unnecessary callback

Makes flags used in handlers volatile to avoid issues