### PR TITLE
Xmclib 2.1.6 changes to reduce compiler warnings and Enhancement

### DIFF
--- a/arm/cores/xmc_lib/XMCLib/inc/xmc_device.h
+++ b/arm/cores/xmc_lib/XMCLib/inc/xmc_device.h
@@ -1,12 +1,12 @@
 /**
  * @file xmc_device.h
- * @date 2016-07-21
+ * @date 2018-03-08
  *
  * @cond
- *********************************************************************************************************************
- * XMClib v2.1.16 - XMC Peripheral Driver Library
+  *********************************************************************************************************************
+ * XMClib v2.1.8 - XMC Peripheral Driver Library
  *
- * Copyright (c) 2015-2017, Infineon Technologies AG
+ * Copyright (c) 2015-2016, Infineon Technologies AG
  * All rights reserved.                        
  *                                             
  * Redistribution and use in source and binary forms, with or without modification,are permitted provided that the 
@@ -53,6 +53,11 @@
  *             XMC1302_T028x0016, XMC1402_T038x0032, XMC1402_T038x0064, XMC1402_T038x0128, 
  *             XMC1403_Q040x0064, XMC1403_Q040x0128, XMC1403_Q040x0200, XMC1402_T038x0200
  *             XMC1402_Q040x0200, XMC1402_Q048x0200, XMC1201_T028x0032
+ *
+ * 2018-03-08:
+ *      - Added defines for XMC1 and XMC47 and XMC48 series to give RAM totals in
+ *        UC_RAm and UC_ALL_RAM
+ *
  * @endcond 
  *
  */
@@ -124,6 +129,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   BGA196
 #define UC_FLASH     (2048UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (352UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -134,6 +141,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (2048UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (352UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -144,6 +153,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (2048UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (352UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -154,6 +165,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   BGA196
 #define UC_FLASH     (1536UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -164,6 +177,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (1536UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -174,6 +189,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (1536UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -184,6 +201,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   BGA196
 #define UC_FLASH     (1024UL)
+#define UC_RAM       (72UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -194,6 +213,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (1024UL)
+#define UC_RAM       (72UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -204,6 +225,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (1024UL)
+#define UC_RAM       (72UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -214,6 +237,8 @@
 #define UC_DEVICE    XMC4700
 #define UC_PACKAGE   BGA196
 #define UC_FLASH     (2048UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (352UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -224,6 +249,8 @@
 #define UC_DEVICE    XMC4700
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (2048UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (352UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -234,6 +261,8 @@
 #define UC_DEVICE    XMC4700
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (2048UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (352UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -244,6 +273,8 @@
 #define UC_DEVICE    XMC4700
 #define UC_PACKAGE   BGA196
 #define UC_FLASH     (1536UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -254,6 +285,8 @@
 #define UC_DEVICE    XMC4700
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (1536UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -264,6 +297,8 @@
 #define UC_DEVICE    XMC4700
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (1536UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -274,6 +309,8 @@
 #define UC_DEVICE    XMC4500
 #define UC_PACKAGE   BGA144
 #define UC_FLASH     (1024UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (80UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -283,6 +320,8 @@
 #define UC_DEVICE    XMC4500
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (1024UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (80UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -292,6 +331,8 @@
 #define UC_DEVICE    XMC4500
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (1024UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (80UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -301,6 +342,8 @@
 #define UC_DEVICE    XMC4500
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (768UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (80UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -310,6 +353,8 @@
 #define UC_DEVICE    XMC4500
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (768UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (80UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -319,6 +364,8 @@
 #define UC_DEVICE    XMC4502
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (768UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (80UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -328,6 +375,8 @@
 #define UC_DEVICE    XMC4504
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (512UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (64UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -337,6 +386,8 @@
 #define UC_DEVICE    XMC4504
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (512UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (64UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -913,6 +964,8 @@
 #define UC_DEVICE    XMC1301
 #define UC_PACKAGE   TSSOP38
 #define UC_FLASH     (16UL)
+#define UC_RAM       (16UL)
+#define UC_ALL_RAM   (16UL)
 #define CCU4V2
 #define CCU8V2
 
@@ -1028,6 +1081,8 @@
 #define UC_DEVICE    XMC1302
 #define UC_PACKAGE   TSSOP38
 #define UC_FLASH     (64UL)
+#define UC_RAM       (16UL)
+#define UC_ALL_RAM   (16UL)
 #define CCU4V2
 #define CCU8V2
 
@@ -1454,6 +1509,35 @@
 #else
 #error "xmc_device.h: device not supported"
 #endif 	    
+#if UC_FAMILY == XMC1
+#define UC_RAM       (16UL)
+#define UC_ALL_RAM   (16UL)
+#endif
+
+#if UC_FAMILY == XMC41
+#define UC_RAM       (8UL)
+#define UC_ALL_RAM   (20UL)
+#endif
+
+#if UC_FAMILY == XMC42
+#define UC_RAM       (16UL)
+#define UC_ALL_RAM   (40UL)
+#endif
+
+#if UC_FAMILY == XMC43
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (128UL)
+#endif
+
+#if UC_FAMILY == XMC44
+#define UC_RAM       (16UL)
+#define UC_ALL_RAM   (80UL)
+#endif
+
+#if UC_FAMILY == XMC45
+#define UC_RAM       (8UL)
+#define UC_ALL_RAM   (20UL)
+#endif
 
 #if UC_SERIES == XMC45
 #include "XMC4500.h"

--- a/arm/cores/xmc_lib/XMCLib/inc/xmc_sdmmc.h
+++ b/arm/cores/xmc_lib/XMCLib/inc/xmc_sdmmc.h
@@ -1,4 +1,3 @@
-
 /**
  * @file xmc_sdmmc.h
  * @date 2017-02-14
@@ -605,7 +604,7 @@ bool XMC_SDMMC_GetPowerStatus(XMC_SDMMC_t *const sdmmc);
  * \par
  * The function de-asserts the peripheral reset. The peripheral needs to be initialized.
  */
-void XMC_SDMMC_Enable(XMC_SDMMC_t *const sdmmc);
+void XMC_SDMMC_Enable( );
 
 /**
  * @param sdmmc A constant pointer to XMC_SDMMC_t, pointing to the SDMMC base address
@@ -617,7 +616,7 @@ void XMC_SDMMC_Enable(XMC_SDMMC_t *const sdmmc);
  * \par
  * The function asserts the peripheral reset.
  */
-void XMC_SDMMC_Disable(XMC_SDMMC_t *const sdmmc);
+void XMC_SDMMC_Disable( );
 
 /**
  * @param sdmmc A constant pointer to XMC_SDMMC_t, pointing to the SDMMC base address
@@ -1394,11 +1393,9 @@ __STATIC_INLINE bool XMC_SDMMC_GetContinueRequest(XMC_SDMMC_t *const sdmmc)
  * at block gap for a multi-block transfer. This bit is only valid in a 4-bit mode of
  * the SDIO card.
  */
-__STATIC_INLINE void XMC_SDMMC_EnableInterruptAtBlockGap(XMC_SDMMC_t *const sdmmc, const XMC_SDMMC_CONFIG_t *config)
+__STATIC_INLINE void XMC_SDMMC_EnableInterruptAtBlockGap( XMC_SDMMC_t *const sdmmc )
 {
   XMC_ASSERT("XMC_SDMMC_EnableInterruptAtBlockGap: Invalid module pointer", XMC_SDMMC_CHECK_MODULE_PTR(sdmmc));
-  XMC_ASSERT("XMC_SDMMC_EnableInterruptAtBlockGap: This operation is only valid in 4-bit mode",
-             (config->bus_width == XMC_SDMMC_DATA_LINES_1));
 
   sdmmc->BLOCK_GAP_CTRL |= (uint8_t)SDMMC_BLOCK_GAP_CTRL_INT_AT_BLOCK_GAP_Msk;
 }
@@ -1415,13 +1412,10 @@ __STATIC_INLINE void XMC_SDMMC_EnableInterruptAtBlockGap(XMC_SDMMC_t *const sdmm
  * The function resets the BLOCK_GAP_CTRL.INT_AT_BLOCK_GAP bit-field to disable interrupt
  * at block gap. This bit is only valid in a 4-bit mode of the SDIO card.
  */
-__STATIC_INLINE void XMC_SDMMC_DisableInterruptAtBlockGap(XMC_SDMMC_t *const sdmmc,
-                                                          const XMC_SDMMC_CONFIG_t *config)
+__STATIC_INLINE void XMC_SDMMC_DisableInterruptAtBlockGap(XMC_SDMMC_t *const sdmmc )
 
 {
   XMC_ASSERT("XMC_SDMMC_EnableInterruptAtBlockGap: Invalid module pointer", XMC_SDMMC_CHECK_MODULE_PTR(sdmmc));
-  XMC_ASSERT("XMC_SDMMC_EnableInterruptAtBlockGap: This operation is only valid in 4-bit mode",
-             (config->bus_width == XMC_SDMMC_DATA_LINES_1));
 
   sdmmc->BLOCK_GAP_CTRL &= (uint8_t)~SDMMC_BLOCK_GAP_CTRL_INT_AT_BLOCK_GAP_Msk;
 }

--- a/arm/cores/xmc_lib/XMCLib/inc/xmc_usbh.h
+++ b/arm/cores/xmc_lib/XMCLib/inc/xmc_usbh.h
@@ -283,18 +283,12 @@ typedef struct XMC_USBH_DRIVER {
   int32_t               (*PortResume)            (uint8_t port);                             /**< Pointer to \ref ARM_USBH_PortResume : Resume Root HUB Port (start generating SOFs). */
   XMC_USBH_PORT_STATE_t   (*PortGetState)          (uint8_t port);                           /**< Pointer to \ref ARM_USBH_PortGetState : Get current Root HUB Port State. */
   XMC_USBH_PIPE_HANDLE  (*PipeCreate)            (uint8_t dev_addr,
-                                                  uint8_t dev_speed,
-                                                  uint8_t hub_addr,
-                                                  uint8_t hub_port,
                                                   uint8_t ep_addr,
                                                   uint8_t ep_type,
                                                   uint16_t ep_max_packet_size,
                                                   uint8_t ep_interval);                      /**< Pointer to \ref ARM_USBH_PipeCreate : Create Pipe in System. */
   int32_t               (*PipeModify)            (XMC_USBH_PIPE_HANDLE pipe_hndl,
                                                   uint8_t dev_addr,
-                                                  uint8_t dev_speed,
-                                                  uint8_t hub_addr,
-                                                  uint8_t hub_port,
                                                   uint16_t ep_max_packet_size);              /**< Pointer to \ref ARM_USBH_PipeModify : Modify Pipe in System. */
   int32_t               (*PipeDelete)            (XMC_USBH_PIPE_HANDLE pipe_hndl);           /**< Pointer to \ref ARM_USBH_PipeDelete : Delete Pipe from System. */
   int32_t               (*PipeReset)             (XMC_USBH_PIPE_HANDLE pipe_hndl);           /**< Pointer to \ref ARM_USBH_PipeReset : Reset Pipe. */
@@ -357,8 +351,8 @@ extern "C" {
  * calls the relevant callback functions to indicate it to the application.
  */
 void XMC_USBH_HandleIrq (uint32_t gintsts);
+
 /**
- * @param ms Delay in milliseconds.
  * @return uint8_t Value has no significance for the low level driver.
  *
  * \par<b>Description:</b><br>
@@ -366,7 +360,7 @@ void XMC_USBH_HandleIrq (uint32_t gintsts);
  * for delay which has to re-implemented with time delay logic. The low level driver expects blocking
  * implementation of the delay.
  */
- uint8_t XMC_USBH_osDelay(uint32_t ms);
+ uint8_t XMC_USBH_osDelay( );
  
 /**
  * @param port Address of the port which has the pin used to enable VBUS charge pump.

--- a/arm/cores/xmc_lib/XMCLib/inc/xmc_vadc.h
+++ b/arm/cores/xmc_lib/XMCLib/inc/xmc_vadc.h
@@ -1529,9 +1529,10 @@ __STATIC_INLINE void XMC_VADC_GLOBAL_ClockInit(XMC_VADC_GLOBAL_t *const global_p
  * None
  *
  */
-
+#if( UC_SERIES != XMC11 )
 void XMC_VADC_GLOBAL_InputClassInit(XMC_VADC_GLOBAL_t *const global_ptr, const XMC_VADC_GLOBAL_CLASS_t config,
                                           const XMC_VADC_GROUP_CONV_t conv_type, const uint32_t set_num);
+#endif
 
 /**
  *

--- a/arm/cores/xmc_lib/XMCLib/src/xmc_sdmmc.c
+++ b/arm/cores/xmc_lib/XMCLib/src/xmc_sdmmc.c
@@ -171,10 +171,8 @@ bool XMC_SDMMC_GetPowerStatus(XMC_SDMMC_t *const sdmmc)
  * De-assert the peripheral reset. The SDMMC peripheral
  * needs to be initialized
  */
-void XMC_SDMMC_Enable(XMC_SDMMC_t *const sdmmc)
+void XMC_SDMMC_Enable( )
 {
-  XMC_ASSERT("XMC_SDMMC_Enable: Invalid module pointer", XMC_SDMMC_CHECK_MODULE_PTR(sdmmc));
-
 #if defined(CLOCK_GATING_SUPPORTED)
   XMC_SCU_CLOCK_UngatePeripheralClock(XMC_SCU_PERIPHERAL_CLOCK_SDMMC);
 #endif
@@ -184,9 +182,8 @@ void XMC_SDMMC_Enable(XMC_SDMMC_t *const sdmmc)
 }
 
 /* Assert the peripheral reset */
-void XMC_SDMMC_Disable(XMC_SDMMC_t *const sdmmc)
+void XMC_SDMMC_Disable( )
 {
-  XMC_ASSERT("XMC_SDMMC_Disable: Invalid module pointer", XMC_SDMMC_CHECK_MODULE_PTR(sdmmc));
 
 #if defined(PERIPHERAL_RESET_SUPPORTED)
   XMC_SCU_RESET_AssertPeripheralReset(XMC_SCU_PERIPHERAL_RESET_SDMMC);

--- a/arm/cores/xmc_lib/XMCLib/src/xmc_usbh.c
+++ b/arm/cores/xmc_lib/XMCLib/src/xmc_usbh.c
@@ -704,9 +704,6 @@ static XMC_USBH_PORT_STATE_t XMC_USBH_PortGetState (uint8_t port)
 
 /**
  * @param dev_addr Device address
- * @param dev_speed  Device speed
- * @param hub_addr Hub address. This value should be 0 since hub is not supported.
- * @param hub_port  USB port number. Only one port(0) is supported.
  * @param ep_addr Device endpoint address \n
  *                - ep_addr.0..3: Address \n
  *                - ep_addr.7:    Direction\n
@@ -721,7 +718,8 @@ static XMC_USBH_PORT_STATE_t XMC_USBH_PortGetState (uint8_t port)
  * \par<b>Related APIs:</b><BR>
  * XMC_USBH_PipeModify(), XMC_USBH_PipeDelete(), XMC_USBH_PipeReset(), XMC_USBH_PipeTransfer() \n
 */
-static XMC_USBH_PIPE_HANDLE XMC_USBH_PipeCreate (uint8_t dev_addr, uint8_t dev_speed, uint8_t hub_addr, uint8_t hub_port, uint8_t ep_addr, uint8_t ep_type, uint16_t ep_max_packet_size, uint8_t  ep_interval) {
+static XMC_USBH_PIPE_HANDLE XMC_USBH_PipeCreate (uint8_t dev_addr,  uint8_t ep_addr, uint8_t ep_type, uint16_t ep_max_packet_size, uint8_t  ep_interval)
+{
   XMC_USBH0_pipe_t    *ptr_pipe;
   USB0_CH_TypeDef *ptr_ch;
   uint32_t         i;
@@ -794,9 +792,6 @@ static XMC_USBH_PIPE_HANDLE XMC_USBH_PipeCreate (uint8_t dev_addr, uint8_t dev_s
 /**
  * @param pipe_hndl Pointer returned by the pipe create function. It is the hardware based address of a USB channel.
  * @param dev_addr Device address to be configured for the pipe.
- * @param dev_speed  Device speed class.
- * @param hub_addr Hub address. It should be 0 since hub is not supported.
- * @param hub_port USB port number. Only one port(0) is supported.
  * @param ep_max_packet_size Endpoint maximum packet size
  * @return Execution_status
  *
@@ -806,7 +801,9 @@ static XMC_USBH_PIPE_HANDLE XMC_USBH_PipeCreate (uint8_t dev_addr, uint8_t dev_s
  * \par<b>Related APIs:</b><BR>
  * XMC_USBH_PipeCreate(), XMC_USBH_PipeDelete(), XMC_USBH_PipeReset(), XMC_USBH_PipeTransfer() \n
 */
-static int32_t XMC_USBH_PipeModify (XMC_USBH_PIPE_HANDLE pipe_hndl, uint8_t dev_addr, uint8_t dev_speed, uint8_t hub_addr, uint8_t hub_port, uint16_t ep_max_packet_size) {
+static int32_t XMC_USBH_PipeModify (XMC_USBH_PIPE_HANDLE pipe_hndl, uint8_t dev_addr, uint16_t ep_max_packet_size)
+{
+
   XMC_USBH0_pipe_t    *ptr_pipe;
   USB0_CH_TypeDef *ptr_ch;
   uint32_t   hcchar;
@@ -1475,7 +1472,7 @@ XMC_USBH_DRIVER_t Driver_USBH0 = {
 
 
 /*Weak definition of delay function*/
-__WEAK uint8_t XMC_USBH_osDelay(uint32_t MS)
+__WEAK uint8_t XMC_USBH_osDelay( )
 {
   /*A precise time delay implementation for this function has to be provided*/
   while (1)

--- a/arm/cores/xmc_lib/XMCLib/src/xmc_vadc.c
+++ b/arm/cores/xmc_lib/XMCLib/src/xmc_vadc.c
@@ -232,6 +232,7 @@ void XMC_VADC_GLOBAL_Init(XMC_VADC_GLOBAL_t *const global_ptr, const XMC_VADC_GL
 
 }
 
+#if( UC_SERIES != XMC11 )
 /* API to Set the Global IClass registers*/
 void XMC_VADC_GLOBAL_InputClassInit(XMC_VADC_GLOBAL_t *const global_ptr, const XMC_VADC_GLOBAL_CLASS_t config,
                                           const XMC_VADC_GROUP_CONV_t conv_type, const uint32_t set_num)
@@ -255,6 +256,7 @@ void XMC_VADC_GLOBAL_InputClassInit(XMC_VADC_GLOBAL_t *const global_ptr, const X
   }
 #endif
 }
+#endif
 
 /* API to enable startup calibration feature */
 void XMC_VADC_GLOBAL_StartupCalibration(XMC_VADC_GLOBAL_t *const global_ptr)

--- a/arm/variants/XMC1100/linker_script.ld
+++ b/arm/variants/XMC1100/linker_script.ld
@@ -1,10 +1,10 @@
 /**
  * @file XMC1100x0064.ld
- * @date 2017-04-20
+ * @date 2018-03-08
  *
  * @cond
  *********************************************************************************************************************
- * Linker file for the GNU C Compiler v1.11
+ * Linker file for the GNU C Compiler v1.9
  * Supported devices: XMC1100-T016F0064
  *                    XMC1100-T016X0064
  *                    XMC1100-T038F0064
@@ -12,7 +12,7 @@
  *                    XMC1100-Q024F0064
  *                    XMC1100-Q040F0064
  *
- * Copyright (c) 2015-2017, Infineon Technologies AG
+ * Copyright (c) 2015-2016, Infineon Technologies AG
  * All rights reserved.                        
  *                                             
  * Redistribution and use in source and binary forms, with or without modification,are permitted provided that the 
@@ -52,14 +52,10 @@
  * 2016-03-15:
  *     - Add assertion to check that region SRAM_combined does not overflowed no_init section 
  *
- * 2016-10-28:
- *     - Fix linker not complaining if sum of data + text sections is bigger that physical FLASH size
- *         
- * 2017-04-07:
- *     - Added new symbols __text_size and eText
- *                   
- * 2017-04-20:
- *     - Change vtable location to flash area to save ram             
+ * 2018-03-08:
+ *     - Change default XMC1xxx stack size
+ *     - Move Stack to top of RAM below no_init for more standard and safer location
+ *     - Could mean startup_XMC1xxx.S could be shortened
  *
  * @endcond 
  *
@@ -108,10 +104,7 @@ SECTIONS
 
       *(.rodata .rodata.*)
       *(.gnu.linkonce.r*)
-
-      *(vtable)        
-
-      . = ALIGN(4);
+      . = ALIGN(4); 
     } > FLASH
 
     .eh_frame_hdr : ALIGN (4)
@@ -139,33 +132,30 @@ SECTIONS
     __exidx_end = .;
     . = ALIGN(4);
 
-    /* DSRAM layout (Lowest to highest)*/
-    /* Veneer <-> Stack <-> DATA <-> BSS <-> HEAP */
+    /* End of RO-DATA and start of LOAD region for the veneers */
+    eROData = . ;
 
-    .VENEER_Code ABSOLUTE(0x2000000C):
+    /* DSRAM layout (Lowest to highest)*/
+    /* Veneer <-> DATA <-> ram_code <-> BSS <-> HEAP <-> memory gap <-> Stack <-> no_init */
+
+    .VENEER_Code ABSOLUTE(0x2000000C): AT(eROData)
     {
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
         VeneerStart = .;
         KEEP(*(.XmcVeneerCode));
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
         VeneerEnd = .;
-    } > SRAM AT > FLASH
-    eROData = LOADADDR (.VENEER_Code);
-    VeneerSize = ABSOLUTE(VeneerEnd) - ABSOLUTE(VeneerStart);
-
-    /* Dummy section for stack */
-    Stack (NOLOAD) : AT(0)
-    {
-        . = ALIGN(8);
-        . = . + stack_size;
-        __initial_sp = .;
     } > SRAM
 
+    VeneerSize = ABSOLUTE(VeneerEnd) - ABSOLUTE(VeneerStart);
+
      /* Standard DATA and user defined DATA/BSS/CONST sections */
-    .data :
+    DataLoadAddr = eROData + VeneerSize;
+    .data : AT(DataLoadAddr)
     {
-      . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+      . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
       __data_start = .;
+      *(vtable)        
       * (.data);
       * (.data*);
       *(*.data);
@@ -192,54 +182,63 @@ SECTIONS
       KEEP(*(.fini_array))
       PROVIDE_HIDDEN (__fini_array_end = .);
 
-      . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+      . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
       __data_end = .;
-    } > SRAM AT > FLASH
-    DataLoadAddr = LOADADDR (.data);
+    } > SRAM
     __data_size = __data_end - __data_start;
 
     .ram_code :
     {
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
         __ram_code_start = .;
         /* functions with __attribute__ ((section (".ram_code")))*/
         *(.ram_code)   
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
         __ram_code_end = .;
-    } > SRAM AT > FLASH
+    } > SRAM
     __ram_code_load = LOADADDR (.ram_code);
     __ram_code_size = __ram_code_end - __ram_code_start;
     
-    __text_size = (__exidx_end - sText) + VeneerSize + __data_size + __ram_code_size;
-    eText = sText + __text_size;
-
     /* BSS section */
     .bss (NOLOAD) :
     {
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
         __bss_start = .;
         * (.bss);
         * (.bss*);
         * (COMMON);
         *(.gnu.linkonce.b*)
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
         __bss_end = .;
-        . = ALIGN(8);
         Heap_Bank1_Start = .;
     } > SRAM
     __bss_size = __bss_end - __bss_start;
     
-    /* .no_init section contains SystemCoreClock. See system.c file */
+    _stack_begin = ORIGIN(SRAM) + LENGTH(SRAM) - stack_size - (2 * no_init_size);
+
+    /* Dummy section for stack  */
+    Stack _stack_begin (NOLOAD) :
+    {
+        . = ORIGIN(SRAM) + LENGTH(SRAM) - stack_size - (2 * no_init_size);
+        Heap_Bank1_End = .;
+        __stack_start = .;
+         . = . + stack_size;
+        __stack_end = .;
+        __initial_sp = .;
+    } > SRAM
+
+    /* Heap - Bank1*/
+
+    Heap_Bank1_Size  = Heap_Bank1_End - Heap_Bank1_Start;
+
+    ASSERT(Heap_Bank1_Start <= Heap_Bank1_End, "bss section SRAM overflowed stack section")
+
+    /* .no_init section contains SystemCoreClock. See system_XMC_xxxx.c file */
     .no_init ORIGIN(SRAM) + LENGTH(SRAM) - no_init_size (NOLOAD) : 
     {
-        Heap_Bank1_End = .;
         * (.no_init);
     } > SRAM
     
-    /* Heap - Bank1*/
-    Heap_Bank1_Size  = Heap_Bank1_End - Heap_Bank1_Start;
-
-    ASSERT(Heap_Bank1_Start <= Heap_Bank1_End, "region SRAM overflowed no_init section")
 
     /DISCARD/ :
     {

--- a/arm/variants/XMC1300/linker_script.ld
+++ b/arm/variants/XMC1300/linker_script.ld
@@ -1,14 +1,14 @@
 /**
  * @file XMC1300x0200.ld
- * @date 2017-04-20
+ * @date 2018-03-08
  *
  * @cond
  *********************************************************************************************************************
- * Linker file for the GNU C Compiler v1.12
+ * Linker file for the GNU C Compiler v1.10
  * Supported devices: XMC1302-T038X0200
  *                    XMC1302-Q040X0200
  *
- * Copyright (c) 2015-2017, Infineon Technologies AG
+ * Copyright (c) 2015-2016, Infineon Technologies AG
  * All rights reserved.                        
  *                                             
  * Redistribution and use in source and binary forms, with or without modification,are permitted provided that the 
@@ -51,14 +51,10 @@
  * 2016-06-07:
  *     - Add XMC1302-Q040X0200                                                                                           
  *
- * 2016-10-28:
- *     - Fix linker not complaining if sum of data + text sections is bigger that physical FLASH size
- *
- * 2017-04-07:
- *     - Added new symbols __text_size and eText
- * 
- * 2017-04-20:
- *     - Change vtable location to flash area to save ram             
+ * 2018-03-08:
+ *     - Change default XMC1xxx stack size
+ *     - Move Stack to top of RAM below no_init for more standard and safer location
+ *     - Could mean startup_XMC1xxx.S could be shortened
  *
  * @endcond 
  *
@@ -107,10 +103,7 @@ SECTIONS
 
       *(.rodata .rodata.*)
       *(.gnu.linkonce.r*)
-
-      *(vtable)        
-
-      . = ALIGN(4);
+      . = ALIGN(4); 
     } > FLASH
 
     .eh_frame_hdr : ALIGN (4)
@@ -138,33 +131,30 @@ SECTIONS
     __exidx_end = .;
     . = ALIGN(4);
 
-    /* DSRAM layout (Lowest to highest)*/
-    /* Veneer <-> Stack <-> DATA <-> BSS <-> HEAP */
+    /* End of RO-DATA and start of LOAD region for the veneers */
+    eROData = . ;
 
-    .VENEER_Code ABSOLUTE(0x2000000C):
+    /* DSRAM layout (Lowest to highest)*/
+    /* Veneer <-> DATA <-> ram_code <-> BSS <-> HEAP <-> memory gap <-> Stack <-> no_init */
+
+    .VENEER_Code ABSOLUTE(0x2000000C): AT(eROData)
     {
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
         VeneerStart = .;
         KEEP(*(.XmcVeneerCode));
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
         VeneerEnd = .;
-    } > SRAM AT > FLASH
-    eROData = LOADADDR (.VENEER_Code);
-    VeneerSize = ABSOLUTE(VeneerEnd) - ABSOLUTE(VeneerStart);
-
-    /* Dummy section for stack */
-    Stack (NOLOAD) : AT(0)
-    {
-        . = ALIGN(8);
-        . = . + stack_size;
-        __initial_sp = .;
     } > SRAM
 
+    VeneerSize = ABSOLUTE(VeneerEnd) - ABSOLUTE(VeneerStart);
+
      /* Standard DATA and user defined DATA/BSS/CONST sections */
-    .data :
+    DataLoadAddr = eROData + VeneerSize;
+    .data : AT(DataLoadAddr)
     {
-      . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+      . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
       __data_start = .;
+      *(vtable)        
       * (.data);
       * (.data*);
       *(*.data);
@@ -191,55 +181,64 @@ SECTIONS
       KEEP(*(.fini_array))
       PROVIDE_HIDDEN (__fini_array_end = .);
 
-      . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+      . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
       __data_end = .;
-    } > SRAM AT > FLASH
-    DataLoadAddr = LOADADDR (.data);
+    } > SRAM
     __data_size = __data_end - __data_start;
 
-    .ram_code :
+    .ram_code : AT(DataLoadAddr + __data_size)
     {
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
         __ram_code_start = .;
         /* functions with __attribute__ ((section (".ram_code")))*/
         *(.ram_code)   
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
         __ram_code_end = .;
-    } > SRAM AT > FLASH
+    } > SRAM
     __ram_code_load = LOADADDR (.ram_code);
     __ram_code_size = __ram_code_end - __ram_code_start;
     
-    __text_size = (__exidx_end - sText) + VeneerSize + __data_size + __ram_code_size;
-    eText = sText + __text_size;
-
     /* BSS section */
     .bss (NOLOAD) :
     {
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
         __bss_start = .;
         * (.bss);
         * (.bss*);
         * (COMMON);
         *(.gnu.linkonce.b*)
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC_xxxx.S file */
         __bss_end = .;
-        . = ALIGN(8);
         Heap_Bank1_Start = .;
     } > SRAM
     __bss_size = __bss_end - __bss_start;
     
-    /* .no_init section contains SystemCoreClock. See system.c file */
-    .no_init ORIGIN(SRAM) + LENGTH(SRAM) - no_init_size (NOLOAD) : 
+    _stack_begin = ORIGIN(SRAM) + LENGTH(SRAM) - stack_size - (2 * no_init_size);
+
+    /* Dummy section for stack  */
+    Stack _stack_begin (NOLOAD) :
     {
+        . = ORIGIN(SRAM) + LENGTH(SRAM) - stack_size - (2 * no_init_size);
         Heap_Bank1_End = .;
-        * (.no_init);
+        __stack_start = .;
+         . = . + stack_size;
+        __stack_end = .;
+        __initial_sp = .;
     } > SRAM
-    
+
     /* Heap - Bank1*/
+
     Heap_Bank1_Size  = Heap_Bank1_End - Heap_Bank1_Start;
 
-    ASSERT(Heap_Bank1_Start <= Heap_Bank1_End, "region SRAM overflowed no_init section")
+    ASSERT(Heap_Bank1_Start <= Heap_Bank1_End, "bss section SRAM overflowed stack section")
+    
+    /* .no_init section contains SystemCoreClock. See system_XMC_xxxx.c file */
+    .no_init ORIGIN(SRAM) + LENGTH(SRAM) - no_init_size (NOLOAD) : 
+    {
+        * (.no_init);
+    } > SRAM
 
+    
     /DISCARD/ :
     {
         *(.comment)

--- a/arm/variants/XMC4700/linker_script.ld
+++ b/arm/variants/XMC4700/linker_script.ld
@@ -1,15 +1,15 @@
 /**
  * @file XMC4700x2048.ld
- * @date 2017-04-20
+ * @date 2016-03-08
  *
  * @cond
  *********************************************************************************************************************
- * Linker file for the GNU C Compiler v1.3
+ * Linker file for the GNU C Compiler v1.2
  * Supported devices: XMC4700-E196x2048
  *                    XMC4700-F144x2048
  *                    XMC4700-F100x2048
  *
- * Copyright (c) 2015-2017, Infineon Technologies AG
+ * Copyright (c) 2015-2016, Infineon Technologies AG
  * All rights reserved.                        
  *                                             
  * Redistribution and use in source and binary forms, with or without modification,are permitted provided that the 
@@ -46,12 +46,6 @@
  *     - Fix size of BSS and DATA sections to be multiple of 4
  *     - Add assertion to check that region SRAM_combined does not overflowed no_init section
  *      
- * 2017-04-07:
- *     - Added new symbols __text_size and eText
- * 
- * 2017-04-20:
- *     - Change vtable location to flash area to save ram             
- *
  * @endcond 
  *
  */
@@ -104,34 +98,21 @@ SECTIONS
         *(.rodata .rodata.*)
         *(.gnu.linkonce.r*)
         
-        *(vtable)        
         . = ALIGN(4);        
     } > FLASH_1_cached AT > FLASH_1_uncached
 
-    .eh_frame_hdr : ALIGN (4)
-    {
-      KEEP (*(.eh_frame_hdr))
-    } > FLASH_1_cached AT > FLASH_1_uncached
-  
-    .eh_frame : ALIGN (4)
-    {
-      KEEP (*(.eh_frame))
-    } > FLASH_1_cached AT > FLASH_1_uncached
-
     /* Exception handling, exidx needs a dedicated section */
-    .ARM.extab : ALIGN(4)
+    .ARM.extab :
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
     } > FLASH_1_cached AT > FLASH_1_uncached
 
-    . = ALIGN(4);
     __exidx_start = .;
-    .ARM.exidx : ALIGN(4)
+    .ARM.exidx :
     {
         *(.ARM.exidx* .gnu.linkonce.armexidx.*)
     } > FLASH_1_cached AT > FLASH_1_uncached
     __exidx_end = .;
-    . = ALIGN(4);
     
     /* DSRAM layout (Lowest to highest)*/
     Stack (NOLOAD) : 
@@ -145,10 +126,10 @@ SECTIONS
     /* functions with __attribute__((section(".ram_code"))) */
     .ram_code :
     {
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC-xxxx.S file */
         __ram_code_start = .;
         *(.ram_code)
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC-xxxx.S file */
         __ram_code_end = .;
     } > SRAM_combined AT > FLASH_1_uncached
     __ram_code_load = LOADADDR (.ram_code);
@@ -157,7 +138,7 @@ SECTIONS
     /* Standard DATA and user defined DATA/BSS/CONST sections */
     .data :
     {
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC-xxxx.S file */
         __data_start = .;
         * (.data);
         * (.data*);
@@ -184,25 +165,22 @@ SECTIONS
         KEEP(*(.fini_array))
         PROVIDE_HIDDEN (__fini_array_end = .);
 
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(8); /* section size must be multiple of 4. See startup_XMC-xxxx.S file -> icreased to 8 due to linker warning*/
         __data_end = .;
     } > SRAM_combined AT > FLASH_1_uncached
     __data_load = LOADADDR (.data);
     __data_size = __data_end - __data_start;
         
-    __text_size = (__exidx_end - sText) + __data_size + __ram_code_size;
-    eText = sText + __text_size;
-
     /* BSS section */
     .bss (NOLOAD) : 
     {
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC-xxxx.S file */
         __bss_start = .;
         * (.bss);
         * (.bss*);
         * (COMMON);
         *(.gnu.linkonce.b*)
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC-xxxx.S file */
         __bss_end = .;
     } > SRAM_combined
     __bss_size = __bss_end - __bss_start;
@@ -212,30 +190,31 @@ SECTIONS
 
     USB_RAM  (__bss_end + __shift_loc) (NOLOAD) :
     {
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC-xxxx.S file */
         USB_RAM_start = .;
         *(USB_RAM)
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC-xxxx.S file */
         USB_RAM_end = .;
     } > SRAM_combined
     USB_RAM_size = USB_RAM_end - USB_RAM_start;
 
     ETH_RAM (USB_RAM_end) (NOLOAD) :
     {
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC-xxxx.S file */
         ETH_RAM_start = .;
         *(ETH_RAM)
-        . = ALIGN(4); /* section size must be multiply of 4. See startup.S file */
+        . = ALIGN(4); /* section size must be multiple of 4. See startup_XMC-xxxx.S file */
         ETH_RAM_end = .;
         . = ALIGN(8);
         Heap_Bank1_Start = .;
     } > SRAM_combined
     ETH_RAM_size = ETH_RAM_end - ETH_RAM_start;
 
-    /* .no_init section contains chipid, SystemCoreClock and trimming data. See system.c file*/
+    /* .no_init section contains chipid, SystemCoreClock and trimming data. See startup_XMC-xxxx.c file*/
     .no_init ORIGIN(SRAM_combined) + LENGTH(SRAM_combined) - no_init_size (NOLOAD) : 
     {
         Heap_Bank1_End = .;
+        end = Heap_Bank1_End;
         * (.no_init);
     } > SRAM_combined
 

--- a/arm/variants/XMC4800/linker_script.ld
+++ b/arm/variants/XMC4800/linker_script.ld
@@ -1,15 +1,15 @@
 /**
  * @file XMC4800x2048.ld
- * @date 2017-04-20
+ * @date 2016-03-08
  *
  * @cond
  *********************************************************************************************************************
- * Linker file for the GNU C Compiler v1.3
+ * Linker file for the GNU C Compiler v1.2
  * Supported devices: XMC4800-E196x2048
  *                    XMC4800-F144x2048
  *                    XMC4800-F100x2048
  *
- * Copyright (c) 2015-2017, Infineon Technologies AG
+ * Copyright (c) 2015-2016, Infineon Technologies AG
  * All rights reserved.                        
  *                                             
  * Redistribution and use in source and binary forms, with or without modification,are permitted provided that the 
@@ -49,12 +49,6 @@
  *     - Fix size of BSS and DATA sections to be multiple of 4
  *     - Add assertion to check that region SRAM_combined does not overflowed no_init section  
  *             
- * 2017-04-07:
- *     - Added new symbols __text_size and eText
- * 
- * 2017-04-20:
- *     - Change vtable location to flash area to save ram             
- *
  * @endcond 
  *
  */
@@ -106,10 +100,8 @@ SECTIONS
 
     *(.rodata .rodata.*)
     *(.gnu.linkonce.r*)
-        
-    *(vtable)        
-
-    . = ALIGN(4);        
+     
+    . = ALIGN(4);   
   } > FLASH_1_cached AT > FLASH_1_uncached
 
   .eh_frame_hdr : ALIGN (4)
@@ -149,10 +141,10 @@ SECTIONS
   /* functions with __attribute__((section(".ram_code"))) */
   .ram_code :
   {
-    . = ALIGN(4); /* section size must be multiply of 4 */        
+    . = ALIGN(4); /* section size must be multiple of 4 */        
     __ram_code_start = .;
     *(.ram_code)
-    . = ALIGN(4); /* section size must be multiply of 4 */
+    . = ALIGN(4); /* section size must be multiple of 4 */
     __ram_code_end = .;
   } > SRAM_combined AT > FLASH_1_uncached
   __ram_code_load = LOADADDR (.ram_code);
@@ -161,8 +153,9 @@ SECTIONS
   /* Standard DATA and user defined DATA/BSS/CONST sections */
   .data :
   {
-    . = ALIGN(4); /* section size must be multiply of 4 */        
+    . = ALIGN(4); /* section size must be multiple of 4 */        
     __data_start = .;
+    *(vtable)        
     * (.data);
     * (.data*);
     *(*.data);
@@ -188,25 +181,22 @@ SECTIONS
     KEEP(*(.fini_array))
     PROVIDE_HIDDEN (__fini_array_end = .);
 
-    . = ALIGN(4); /* section size must be multiply of 4 */
+    . = ALIGN(4); /* section size must be multiple of 4 */
     __data_end = .;
   } > SRAM_combined AT > FLASH_1_uncached
   __data_load = LOADADDR (.data);
   __data_size = __data_end - __data_start;
         
-  __text_size = (__exidx_end - sText) + __data_size + __ram_code_size;
-  eText = sText + __text_size;
-        
   /* BSS section */
   .bss (NOLOAD) : 
   {
-    . = ALIGN(4); /* section size must be multiply of 4 */        
+    . = ALIGN(4); /* section size must be multiple of 4 */        
     __bss_start = .;
     * (.bss);
     * (.bss*);
     * (COMMON);
     *(.gnu.linkonce.b*)
-    . = ALIGN(4); /* section size must be multiply of 4 */
+    . = ALIGN(4); /* section size must be multiple of 4 */
     __bss_end = .;
   } > SRAM_combined
   __bss_size = __bss_end - __bss_start;
@@ -216,25 +206,30 @@ SECTIONS
 
   USB_RAM  (__bss_end + __shift_loc) (NOLOAD) :
   {
-    . = ALIGN(4); /* section size must be multiply of 4 */        
+    . = ALIGN(4); /* section size must be multiple of 4 */        
     USB_RAM_start = .;
     *(USB_RAM)
-    . = ALIGN(4); /* section size must be multiply of 4 */
+    . = ALIGN(4); /* section size must be multiple of 4 */
     USB_RAM_end = .;
   } > SRAM_combined
   USB_RAM_size = USB_RAM_end - USB_RAM_start;
 
   ETH_RAM (USB_RAM_end) (NOLOAD) :
   {
-    . = ALIGN(4); /* section size must be multiply of 4 */        
+    . = ALIGN(4); /* section size must be multiple of 4 */        
     ETH_RAM_start = .;
     *(ETH_RAM)
-    . = ALIGN(4); /* section size must be multiply of 4 */
+    . = ALIGN(4); /* section size must be multiple of 4 */
     ETH_RAM_end = .;
     . = ALIGN(8);
     Heap_Bank1_Start = .;
   } > SRAM_combined
   ETH_RAM_size = ETH_RAM_end - ETH_RAM_start;
+
+  __malloc_heap_start = Heap_Bank1_Start;
+  __malloc_heap_end = __malloc_heap_start + 0x2000;
+  end = __malloc_heap_end;
+  __malloc_heap_size = __malloc_heap_end - __malloc_heap_start;
 
   /* .no_init section contains chipid, SystemCoreClock and trimming data. See system.c file*/
   .no_init ORIGIN(SRAM_combined) + LENGTH(SRAM_combined) - no_init_size (NOLOAD) : 


### PR DESCRIPTION
Enhancement  -Add  two new defines to xmc_defines.h on per family or series or chip , which creates defines to report in kB for 

      UC_RAM programme memory only
      UC_ALL_RAM Program and Special meory combined

Tidy ups on linker scripts for spelling mistakes and fuller filenames
XMC1 series reduce RAM wastage and move Stack to less dangerous are to avoid overruns

Reduce compiler warnings still exist compiler warnings in new version of XMCLIB a method of fixing is included as separate committ