### PR TITLE
Updates for Tone/wiring_time adding RAM totals to compile

### DIFF
--- a/arm/cores/Tone.cpp
+++ b/arm/cores/Tone.cpp
@@ -15,167 +15,142 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
-
+/* Tones are Systick timer event related not hardware timer related
+   So take care in selecting frequencies range of 1 - 500 Hz supported */
 
 //****************************************************************************
 // @Project Includes
 //****************************************************************************
 #include "Arduino.h"
-#include "pins_arduino.h"
 
 //****************************************************************************
 // @Macros
 //****************************************************************************
-#define FREQUENCY_TO_MILLIS(f)   (1000/(2*f)
-#define TIMER_TO_IRQ_HANDLER(t)  t==0?TIMER_0_IRQHandler:t==1?TIMER_1_IRQHandler:t==2?TIMER_2_IRQHandler:t==3?TIMER_3_IRQHandler:NULL
+#define FREQUENCY_TO_MILLIS(f)   (SYSTIMER_TICK_PERIOD_US/(2*f))
 
 //****************************************************************************
 // @Defines
 //****************************************************************************
-// Max num of timer: 8 (- 1 for delay funct.)
-#define AVAILABLE_TONE_PINS 4
 
 //****************************************************************************
 // @Global Variables
 //****************************************************************************
-static uint8_t tone_pins[AVAILABLE_TONE_PINS] = { 255, 255, 255, 255 };
-static uint32_t timer_ids[AVAILABLE_TONE_PINS] = { 0, 0, 0, 0 };
-static long timer_toggle_count[AVAILABLE_TONE_PINS] = { 0, 0, 0, 0 };
-
-//****************************************************************************
-// @Prototypes Of Local Functions
-//****************************************************************************
-void TIMER_0_IRQHandler(void);
-void TIMER_1_IRQHandler(void);
-void TIMER_2_IRQHandler(void);
-void TIMER_3_IRQHandler(void);
-
-void timer_irq_action(uint8_t);
+// Valid Arduino pin or 255 for not allocated
+volatile uint8_t tone_pins[ NUM_TONE_PINS ];
+// Toggle counts > 0 toggles to do
+// 0 is next time stop
+// < 0 is continuous running
+volatile long timer_toggle_count[ NUM_TONE_PINS ];
+// arrays initialised
+uint8_t tone_init = 0;
 
 //****************************************************************************
 // @Local Functions
 //****************************************************************************
 
-static int8_t toneBegin(uint8_t _pin)
+static int8_t toneBegin( uint8_t _pin )
 {
-    int8_t _timer = -1;
+int8_t i = -1;
 
-    // if we're already using the pin, the timer should be configured.
-    for (int i = 0; i < AVAILABLE_TONE_PINS; i++)
-    {
-        if (tone_pins[i] == _pin)
-        {
-            return i;
-        }
-    }
+// check all arrays initialised
+if( tone_init == 0 )
+  {
+  // No preset them for number of Tine pins
+  memset( (void *)tone_pins, 255, sizeof( tone_pins ) );
+  memset( (void *)timer_toggle_count, 0, sizeof( timer_toggle_count ) );
+  tone_init++;
+  }
 
-    // search for an unused timer.
-    for (int i = 0; i < AVAILABLE_TONE_PINS; i++)
-    {
-        if (tone_pins[i] == 255)
-        {
-            tone_pins[i] = _pin;
-            pinMode(_pin, OUTPUT);
-            _timer = i;
-            break;
-        }
-    }
+// Once initialised
+// if we're already using the pin, the timer should be configured.
+for( i = 0; i < NUM_TONE_PINS; i++ )
+    if( tone_pins[ i ] == _pin)
+        return i;
 
-    return _timer;
+// search for an unused timer.
+for( i = 0; i < NUM_TONE_PINS; i++ )
+   if( tone_pins[ i ] == 255 )
+     {
+     tone_pins[ i ] = _pin;
+     pinMode( _pin, OUTPUT );
+     break;
+     }
+ 
+return ( i < NUM_TONE_PINS ) ? i : -1;
 }
+
 
 // frequency (in hertz) and duration (in milliseconds).
-void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
+// Max frequency usable = 500 Hz
+// Min frequency usable = 1 Hz
+// Duration default of 0 for permanently on
+// Timer task ID is tone pin index _timer
+void tone( uint8_t _pin, unsigned int frequency, unsigned long duration )
 {
-    long toggle_count = 0;
-    int8_t _timer;
+int8_t _timer;
 
-    _timer = toneBegin(_pin);
+// Check valid frequency range first
+if( frequency > 0 && frequency <= 500 )
+  {
+  _timer = toneBegin( _pin );
 
-    if (_timer >= 0 && _timer < AVAILABLE_TONE_PINS)
+  if( _timer >= 0 && _timer < NUM_TONE_PINS )
     {
-
-        // Calculate the toggle count
-        if (duration > 0)
-        {
-            toggle_count = 2 * frequency * duration / 1000;
-        }
-        else
-        {
-            toggle_count = -1;
-        }
-
-        timer_ids[_timer] = XMC_SYSTIMER_CreateTimer((uint32_t)FREQUENCY_TO_MILLIS(frequency)), XMC_SYSTIMER_MODE_PERIODIC, (XMC_SYSTIMER_CALLBACK_t) (TIMER_TO_IRQ_HANDLER(_timer)), NULL);
-        if (timer_ids[_timer] != 0)
-        {
-            //Timer is created successfully
-            timer_toggle_count[_timer] = toggle_count;
-            XMC_SYSTIMER_StartTimer(timer_ids[_timer]);
-        }
-    }
-}
-
-void disableTimer(uint8_t _timer)
-{
-    if (_timer >= 0 && _timer < AVAILABLE_TONE_PINS)
-    {
-        XMC_SYSTIMER_DeleteTimer(timer_ids[_timer]);
-    }
-}
-
-
-void noTone(uint8_t _pin)
-{
-    int8_t _timer = -1;
-
-    for (int i = 0; i < AVAILABLE_TONE_PINS; i++)
-    {
-        if (tone_pins[i] == _pin)
-        {
-            _timer = i;
-            tone_pins[i] = 255;
-            break;
-        }
-    }
-
-    disableTimer(_timer);
-
-    digitalWrite(_pin, 0);
-}
-
-void TIMER_0_IRQHandler(void)
-{
-    timer_irq_action(0);
-}
-
-void TIMER_1_IRQHandler(void)
-{
-    timer_irq_action(1);
-}
-
-void TIMER_2_IRQHandler(void)
-{
-    timer_irq_action(2);
-}
-
-void TIMER_3_IRQHandler(void)
-{
-    timer_irq_action(3);
-}
-
-void timer_irq_action(uint8_t _timer)
-{
-    if (timer_toggle_count[_timer])
-    {
-        XMC_GPIO_ToggleOutput(mapping_port_pin[tone_pins[_timer]].port, mapping_port_pin[tone_pins[_timer]].pin);
-        timer_toggle_count[_timer]--;
-    }
+    // Calculate the toggle count
+    if( duration > 0 )
+      timer_toggle_count[ _timer ] = 2 * frequency * duration/1000;
     else
-    {
-        disableTimer(_timer);
-        timer_ids[_timer] = 0;
-        digitalWrite(tone_pins[_timer], LOW);
+      timer_toggle_count[ _timer ] = -1;        // Continuous
+    // Set int task parameters
+    setParam( _timer, _timer );
+    setInterval( _timer, (unsigned int)FREQUENCY_TO_MILLIS( frequency ) );
+    StartTask( _timer );
     }
+  }
+}
+
+
+// Stops tone at next 1ms Systick
+void noTone( uint8_t _pin )
+{
+int8_t i = -1;
+
+for( i = 0; i < NUM_TONE_PINS; i++ )
+   if( tone_pins[ i ] == _pin )
+     {
+     tone_pins[ i ] = 255;
+     break;
+     }
+
+if( i < NUM_TONE_PINS )   // Only if found set to stop at max next Systick event
+  {    
+  noInterrupts( );              // Interrupt disable guard to be safe
+  timer_toggle_count[ i ] = 0;  // Stop on next Systick
+  setInterval( i, 1 );
+  interrupts( );
+  }
+}
+
+
+/* Interrupt GPIO action
+     On normal operation to continue returns 1
+     On end of operations returns 0 to stop tasks   
+*/
+int tone_irq_action( int ID, int16_t tone )
+{
+if( timer_toggle_count[ tone ] )
+  {
+  digitalToggle( tone_pins[ tone ] );
+  if( timer_toggle_count[ tone ] > 0 )
+    timer_toggle_count[ tone ]--;
+  }
+else
+  {
+  setInterval( ID, 0 );         // no longer wanted to run
+  digitalWrite( tone_pins[ tone ], LOW );
+  return 0;
+  }
+return 1;  
 }
 
 //****************************************************************************

--- a/arm/cores/Tone.h
+++ b/arm/cores/Tone.h
@@ -15,14 +15,21 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
-
 #ifndef _WIRING_TONE_
 #define _WIRING_TONE_
 
 //****************************************************************************
 // @External Prototypes
 //****************************************************************************
-void tone(uint8_t, unsigned int , unsigned long);
-void noTone(uint8_t);
+extern void tone( uint8_t, unsigned int, unsigned long = 0 );
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+extern void noTone( uint8_t );
+extern int  tone_irq_action( int, int16_t );
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _WIRING_TONE_ */

--- a/arm/cores/wiring_time.c
+++ b/arm/cores/wiring_time.c
@@ -16,546 +16,484 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+/* Includes Co-operative Scheduler for XMC-for-Arduino
+
+   Using COMPILE time scheduling table 
+
+Version V1.00
+Author: Paul Carpenter, PC Services, <sales@pcserviceselectronics.co.uk>
+Date    March 2018
+
+Co-operative scheduler library that has some support functions and main 
+schedule function meant to be run as the Systick scheduler event handler, the 
+support functions should be used to get status on, start, stop, or configure tasks.
+
+The schedule code is designed for MINIMAL overhead and SPEED.
+
+The time interval of calling the schedule loop is determined by Systick timer 
+interval currently 1 ms, and calls a selection of tasks determined by two
+parameters for each task
+
+    callback    function address
+    parameter   INTEGER to pass to function
+    
+From this we get TWO types of function calls when a task event happens
+
+1/ callback and parameter are set gives a function call of
+
+    int callback( int ID, int16_t param )
+            function to use as this task that accepts TWO integer parameters
+            and MUST return an integer
+
+   (even if parameter not set it is initialised to task_id AT compile TIME)
+    
+2/ Special case if ANY task has its callback set to NULL a special variable
+   in wiring_time is set to TRUE. This enables the delay() function to work
+   for ms delays. As a side effect it stops runaway tasks for callback set to 
+   NULL. 
+                            
+Callback functions in list
+--------------------------
+    For different processors speeds it is suggested to keep the number of 
+    total tasks (callback functions) to following limits -
+    
+    Speed               Max Tasks
+    < 50 MHz            8
+    > 50 MHz < 100 MHz  12
+    > 100 MHz           16
+
+Callback function structure
+---------------------------
+    Task is actually calling a function that should be defined as 
+    function that returns int and takes TWO integer parameter
+
+    e.g.    int func( int TaskId, int16_t Parameter )
+    First parameter is TaskId,
+    Second parameter is user defined parameter (int16_t)
+
+    If interval of a task has to change call setInterval during task execution
+    NOT to STOP task use return code
+
+Callback functions Contents
+---------------------------
+    Callback functions are effectively interrupt routines so care should be taken 
+    about which variables and flags set in these functions are volatiles.
+    
+    Functions MUST be VERY SMALL as many tasks have to run in less than 1 ms as 
+    well as the main code.
+    
+    Do NOT use blocking or slow callbacks that use AT LEAST the following Ardunio
+    functions
+        delay           (this would become recursive)
+        .print, .write, println on Serial or Liquid Crystal
+        analogread
+        PulseIn
+        Liquid Crystal  ANY function
+        I2C or SPI      ANY function
+        SD/MMC          ANY function
+
+    All of these and maybe others are SLOW, block waiting for I/O or time
+    delays often MUCH longer than 1 ms
+
+Callback Function Return value
+------------------------------
+    The returned value is the NEW status for that task which tells scheduler
+    what to do next time. Values are
+
+      < 0 User error status (stops task execution)
+        0  Task stopped (if needed to be run will have to be started by Start)
+      > 0 Next status this can be used by call back function for state machines
+          Task runs again at the interval set
+
+Scheduling Functions
+--------------------
+setInterval Set a task's NEW interval and schedule new time from now if not
+            already running
+getInterval Get a task's interval
+setParam    Set a task's callback function parameter (signed int16_t)
+getParam    Get a task's callback function parameter (signed int16_t)
+getTime     Get a task's next time to execute
+getStatus   Get a particular task status word
+StartTask   Start a task (if not already running)
+FindID      get ID of first task from task address
+*/
 //****************************************************************************
 // @Project Includes
 //****************************************************************************
 #include "Arduino.h"
-//****************************************************************************
-// @Macros
-//****************************************************************************
+extern int  tone_irq_action( int, int16_t );
 
 //****************************************************************************
 // @Defines
 //****************************************************************************
-/**< SysTick interval in seconds */
-#define SYSTIMER_TICK_PERIOD  (0.001F)
-
-/**< SysTick number of ticks per ms*/
-#define SYSTIMER_TICKS_FOR_ONE_MS (F_CPU / 1000u)
-/**< SysTick number of ticks per us*/
-#define SYSTIMER_TICKS_FOR_ONE_US (F_CPU / 1000000u)
-
-/**< Maximum No of timer */
-#define SYSTIMER_CFG_MAX_TMR  (8U)
+// number of tasks = number of tones plus delay task plus any others added later
+#define _MAX_TASKS   (NUM_TONE_PINS + 1)
 
 #define SYSTIMER_PRIORITY  (4U)
-
-#define HW_TIMER_ADDITIONAL_CNT (1U)
-
-//****************************************************************************
-// @Typedefs
-//****************************************************************************
-/* SYSTIMER_OBJECT structure acts as the timer control block */
-typedef struct XMC_SYSTIMER_OBJECT
-{
-    struct XMC_SYSTIMER_OBJECT* next; /**< pointer to next timer control block */
-    struct XMC_SYSTIMER_OBJECT* prev; /**< Pointer to previous timer control block */
-    XMC_SYSTIMER_CALLBACK_t callback; /**< Callback function pointer */
-    XMC_SYSTIMER_MODE_t mode; /**< timer Type (single shot or periodic) */
-    XMC_SYSTIMER_STATE_t state; /**< timer state */
-    void* args; /**< Parameter to callback function */
-    uint32_t id; /**< timer ID */
-    uint32_t count; /**< timer count value */
-    uint32_t reload; /**< timer Reload count value */
-    bool delete_swtmr; /**< To delete the timer */
-} XMC_SYSTIMER_OBJECT_t;
+/* Millisecond to Microsecond ratio */
+#define TIMER_1mSec 1000
 
 //****************************************************************************
 // @Global Variables
 //****************************************************************************
-/** Table which save timer control block. */
-XMC_SYSTIMER_OBJECT_t g_timer_tbl[SYSTIMER_CFG_MAX_TMR];
+/* Array of tasks which are addresses to functions.
+    Each function returns int and takes TWO integer parameter
+        e.g.    int func( int TaskId, int16_t Parameter )
+     First parameter is TaskId,
+     second is current status is user defined parameter (int16_t)
 
-/* The header of the timer Control list. */
-XMC_SYSTIMER_OBJECT_t* g_timer_list = NULL;
+    Tasklist order is ALWAYS
+            Tone    callbacks ( 0 to NUM_TONE_PINS )
+            Any additional tasks
+            delay() callback
 
-/* Timer ID tracker */
-uint32_t g_timer_tracker = 0U;
+    This way last is always delay and first 'n' are always Tone pins i.e. 0 - n
+    last is _MAX_TASKS - 1
+*/
+int (* tasks[_MAX_TASKS])( int, int16_t ); 
 
-/* Tracker if Timer Handler as already been entered -> avoid recursion */
-volatile uint16_t g_timer_entered_handler = 0u;
+/* Structure for task details next run, status etc.. */
+struct TaskList taskTable[ _MAX_TASKS ];
+
+unsigned long old_ms;       // last execution time
+int running;                // Current task ID being checked or run
 
 /* SysTick counter */
 volatile uint32_t g_systick_count = 0U;
 
-__IO bool delay_timer_expired;
+/* Tracker if Timer Handler as already been entered -> avoid recursion */
+volatile __IO bool g_timer_entered_handler = FALSE;
+
+// Delay ms function flag for time expired in Systick Event Handler
+volatile __IO bool delay_timer_expired = FALSE;
 
 //****************************************************************************
 // @Prototypes Of Local Functions
 //****************************************************************************
+/* Handler function  called from SysTick event handler for task scheduling */
+int XMC_SYSTIMER_lTimerHandler( void );
 
-/*
- * This function is called to insert a timer into the timer list.
- */
-static void XMC_SYSTIMER_lInsertTimerList(uint32_t tbl_index);
+/* SysTick handler which is the main interrupt service routine to service the
+ * tasks configured */
+void SysTick_Handler( void );
 
-/*
- * This function is called to remove a timer from the timer list.
- */
-static void XMC_SYSTIMER_lRemoveTimerList(uint32_t tbl_index);
-
-/*
- * Handler function  called from SysTick event handler.
- */
-static void XMC_SYSTIMER_lTimerHandler(void);
-
-/*
- * SysTick handler which is the main interrupt service routine to service the
- * system timer's configured
- */
-void SysTick_Handler(void);
-
-/*
- * cb function called after delay timer is expired
- */
-void delay_cb(void* Temp);
 
 //****************************************************************************
 // @Local Functions
 //****************************************************************************
-void wiring_time_init(void)
+void wiring_time_init( void )
 {
-    /* Initialize the header of the list */
-    g_timer_list = NULL;
-    /* Initialize SysTick timer */
-    SysTick_Config((uint32_t)SYSTIMER_TICKS_FOR_ONE_MS);
-    /* setting of priority value*/
-    NVIC_SetPriority(SysTick_IRQn, SYSTIMER_PRIORITY);
-	
-    g_timer_tracker = 0U;
+// Initialise task control to all off
+memset( taskTable, 0, sizeof( taskTable ) );
+
+for( int i = 0; i < _MAX_TASKS; i++ )
+   {
+   taskTable[ i ].param = i;        // Preset user parameter to task number
+// Fill with call back function addresses
+   if( i < NUM_TONE_PINS )
+     tasks[ i ] = tone_irq_action;   // Tone callbacks
+   else
+     tasks[ i ] = NULL;     // Special case delay() ms callback
+   }
+old_ms = g_systick_count;        // Save last executed as now
+ 
+/* Initialize SysTick timer for 1ms (1kHz) interval */
+SysTick_Config( (uint32_t)SYSTICK_MS );
+
+/* setting of First SW Timer period is always and sub-priority value for XMC4000 devices */
+/* setting of priority value for XMC1000 devices */
+NVIC_SetPriority( SysTick_IRQn, SYSTIMER_PRIORITY );
 }
 
-uint32_t millis(void)
-{
-	// Get Tick value (incremented every ms)
-    return XMC_SYSTIMER_GetTickCount();
-}
 
-uint32_t micros(void)
-{
-	// Combine g_systick_count and current systick value
-	uint32_t micros = (millis() * 1000u) + ((SysTick->LOAD - SysTick->VAL) / (SYSTIMER_TICKS_FOR_ONE_US));
-    return micros;
-}
-
-void delay(uint32_t dwMs)
-{
-    uint32_t TimerId;
-
-    delay_timer_expired = FALSE;
-    /*
-     * This funcion uses SysTick Exception for controlling the timer list. Call back function
-     *   registered through this function will be called in SysTick exception when the timer is expired.
-     *   One shot timers are removed from the timer list, if it expires. To use
-     *   this SW timer again it has to be first deleted and then created again.
-     *
-     *  @param[in]  Period Timer period value in microseconds
-     *  @param[in]  TimerType Type of Timer(ONE_SHOT/PERIODIC)
-     *  @param[in]  TimerCallBack Call back function of the timer(No Macros are allowed)
-     *  @param[in]  pCallBackArgPtr Call back function parameter
-     */
-    TimerId = XMC_SYSTIMER_CreateTimer(dwMs , XMC_SYSTIMER_MODE_ONE_SHOT, delay_cb, NULL);
-    if (TimerId != 0)
-    {
-        //Timer is created successfully
-        XMC_SYSTIMER_StartTimer(TimerId);
-
-        // Wait until timer expires
-		do
-		{
-			yield();
-		}
-        while(!delay_timer_expired);
-
-        // Delete Timer since is One-Shot
-        XMC_SYSTIMER_DeleteTimer(TimerId);
-    }
-}
-
-void delay_cb(void* Temp)
-{
-    delay_timer_expired = TRUE;
-}
-
-/*
- * This function is called to insert a timer into the timer list.
+/* delay - milliseconds
+ * This function uses SysTick Exception for controlling the timer list. Call back function
+ * registered through this function will be called in SysTick exception when the timer is expired.
+ *
+ *  @param[in]  Period Timer period value in microseconds
+ *
+ * Special cases for callback action processing
+ *      callback is NULL boolean delay_timer_expired is set to true
  */
-static void XMC_SYSTIMER_lInsertTimerList(uint32_t tbl_index)
+void delay( uint32_t dwMs )
 {
-    XMC_SYSTIMER_OBJECT_t* object_ptr;
-    int32_t delta_ticks;
-    int32_t timer_count;
-    bool found_flag = false;
-    /* Get timer time */
-    timer_count = (int32_t)g_timer_tbl[tbl_index].count;
-    /* Check if Timer list is NULL */
-    if (NULL == g_timer_list)
-    {
-        /* Set this as first Timer */
-        g_timer_list = &g_timer_tbl[tbl_index];
-    }
-    /* If not, find the correct place, and insert the specified timer */
-    else
-    {
-        object_ptr = g_timer_list;
-        /* Get timer tick */
-        delta_ticks = timer_count;
-        /* Find correct place for inserting the timer */
-        while ((NULL != object_ptr) && (false == found_flag))
-        {
-            /* Get timer Count Difference */
-            delta_ticks -= (int32_t)object_ptr->count;
-            /* Check for delta ticks < 0 */
-            if (delta_ticks <= 0)
-            {
-                /* Check If head item */
-                if (NULL != object_ptr->prev)
-                {
-                    /* If Insert to list */
-                    object_ptr->prev->next = &g_timer_tbl[tbl_index];
-                    g_timer_tbl[tbl_index].prev = object_ptr->prev;
-                    g_timer_tbl[tbl_index].next = object_ptr;
-                    object_ptr->prev = &g_timer_tbl[tbl_index];
-                }
-                else
-                {
-                    /* Set Timer as first item */
-                    g_timer_tbl[tbl_index].next = g_timer_list;
-                    g_timer_list->prev = &g_timer_tbl[tbl_index];
-                    g_timer_list = &g_timer_tbl[tbl_index];
-                }
-                g_timer_tbl[tbl_index].count = g_timer_tbl[tbl_index].next->count + (uint32_t)delta_ticks;
-                g_timer_tbl[tbl_index].next->count  -= g_timer_tbl[tbl_index].count;
-                found_flag = true;
-            }
-            /* Check for last item in list */
-            else
-            {
-                if ((delta_ticks > 0) && (NULL == object_ptr->next))
-                {
-                    /* Yes, insert into */
-                    g_timer_tbl[tbl_index].prev = object_ptr;
-                    object_ptr->next = &g_timer_tbl[tbl_index];
-                    g_timer_tbl[tbl_index].count = (uint32_t)delta_ticks;
-                    found_flag = true;
-                }
-            }
-            /* Get the next item in timer list */
-            object_ptr = object_ptr->next;
-        }
-    }
+setInterval( _MAX_TASKS - 1, dwMs );
+//Timer is always in list as last
+StartTask( _MAX_TASKS - 1 );
+// Wait until timer expires
+do
+  yield( );
+while( !delay_timer_expired );
+delay_timer_expired = FALSE;
 }
 
-/*
- * This function is called to remove a timer from the timer list.
+
+/* Handler function called from SysTick event handler.
+        - Task scheduling loop
+
+   Does ONE pass through scheduling table, checking what tasks are due or 
+   overdue to run.
+
+   Order of task execution is list of tasks
+
+   When task has completed -
+        updates task status with status returned,
+        adjusts next run time using interval specified.
+            If interval is zero execution time set to zero.
+
+   Parameters - NONE
+
+   Returns  int  0  Processed no tasks to run
+                > 0 Number of tasks executed
  */
-static void XMC_SYSTIMER_lRemoveTimerList(uint32_t tbl_index)
+int XMC_SYSTIMER_TaskLoop( void )
 {
-    XMC_SYSTIMER_OBJECT_t* object_ptr;
-    object_ptr = &g_timer_tbl[tbl_index];
-    /* Check whether only one timer available */
-    if ((NULL == object_ptr->prev) && (NULL == object_ptr->next ))
-    {
-        /* set timer list as NULL */
-        g_timer_list = NULL;
-    }
-    /* Check if the first item in timer list */
-    else if (NULL == object_ptr->prev)
-    {
-        /* Remove timer from list, and reset timer list */
-        g_timer_list  = object_ptr->next;
-        g_timer_list->prev = NULL;
-        g_timer_list->count += object_ptr->count;
-        object_ptr->next    = NULL;
-    }
-    /* Check if the last item in timer list */
-    else if (NULL == object_ptr->next)
-    {
-        /* Remove timer from list */
-        object_ptr->prev->next = NULL;
-        object_ptr->prev = NULL;
-    }
-    else
-    {
-        /* Remove timer from list */
-        object_ptr->prev->next  =  object_ptr->next;
-        object_ptr->next->prev  =  object_ptr->prev;
-        object_ptr->next->count += object_ptr->count;
-        object_ptr->next = NULL;
-        object_ptr->prev = NULL;
-    }
+int done;
+unsigned int overdue;
+unsigned long ms;
+
+// Task loop lock
+g_timer_entered_handler = TRUE;
+
+// get current time and overdue
+ms = g_systick_count;
+// Unsigned maths first ensures correct even at wraparound
+overdue = (unsigned int)( ms - old_ms );
+// save current execution time
+old_ms = ms;
+done = 0;
+for( running = 0; running < _MAX_TASKS; running++ )
+   {
+   if( taskTable[ running ].status > 0 )    // task enabled
+     { // check if time to run as in correct interval or overdue
+     if( ms - taskTable[ running ].next <= overdue )
+       {
+       if( tasks[ running ] == NULL )
+         {
+         delay_timer_expired = TRUE;        // Special case of NULL callback function
+         taskTable[ running ].status = 0;   // One shot event so stop task
+         }
+       else  
+         if( ( taskTable[ running ].status = 
+                ( ( *tasks[ running ])( running, taskTable[ running ].param ) ) ) > 0 )
+           taskTable[ running ].next = ms + taskTable[ running ].interval;
+       done++;
+       }
+     }
+   }
+return done;
 }
 
-/*
- * Handler function called from SysTick event handler.
- */
-static void XMC_SYSTIMER_lTimerHandler(void)
+
+/* SysTick Event Handler. */
+void SysTick_Handler( void )
 {
-    XMC_SYSTIMER_OBJECT_t* object_ptr;
-    /* Handler entered */
-    g_timer_entered_handler++;
-    /* Get first item of timer list */
-    object_ptr = g_timer_list;
-    while ((NULL != object_ptr) && (0U == object_ptr->count))
-    {
-        if (true == object_ptr->delete_swtmr)
-        {
-            /* Yes, remove this timer from timer list */
-            XMC_SYSTIMER_lRemoveTimerList((uint32_t)object_ptr->id);
-            /* Set timer status as SYSTIMER_STATE_NOT_INITIALIZED */
-            object_ptr->state = XMC_SYSTIMER_STATE_NOT_INITIALIZED;
-            /* Release resource which are hold by this timer */
-            g_timer_tracker &= ~(1U << object_ptr->id);
-        }
-        /* Check whether timer is a one shot timer */
-        else if (XMC_SYSTIMER_MODE_ONE_SHOT == object_ptr->mode)
-        {
-            if (XMC_SYSTIMER_STATE_RUNNING == object_ptr->state)
-            {
-                /* Yes, remove this timer from timer list */
-                XMC_SYSTIMER_lRemoveTimerList((uint32_t)object_ptr->id);
-                /* Set timer status as SYSTIMER_STATE_STOPPED */
-                object_ptr->state = XMC_SYSTIMER_STATE_STOPPED;
-                /* Call timer callback function */
-                (object_ptr->callback)(object_ptr->args);
-            }
-        }
-        /* Check whether timer is periodic timer */
-        else if (XMC_SYSTIMER_MODE_PERIODIC == object_ptr->mode)
-        {
-            if (XMC_SYSTIMER_STATE_RUNNING == object_ptr->state)
-            {
-                /* Yes, remove this timer from timer list */
-                XMC_SYSTIMER_lRemoveTimerList((uint32_t)object_ptr->id);
-                /* Reset timer tick */
-                object_ptr->count = object_ptr->reload;
-                /* Insert timer into timer list */
-                XMC_SYSTIMER_lInsertTimerList((uint32_t)object_ptr->id);
-                /* Call timer callback function */
-                (object_ptr->callback)(object_ptr->args);
-            }
-        }
-        else
-        {
-            break;
-        }
-        /* Get first item of timer list */
-        object_ptr = g_timer_list;
-    }
+g_systick_count++;          // Another ms has occured
+
+// do not call handler, when still running
+if( g_timer_entered_handler == FALSE )
+  {
+  //g_timer_entered_handler++;
+  XMC_SYSTIMER_TaskLoop();
+  g_timer_entered_handler = FALSE;
+  }
 }
 
-/*
- *  SysTick Event Handler.
- */
-void SysTick_Handler(void)
-{
-    XMC_SYSTIMER_OBJECT_t* object_ptr;
-    object_ptr = g_timer_list;
-    g_systick_count++;
 
-    if (NULL != object_ptr)
-    {
-        if (object_ptr->count > 1UL)
-        {
-            object_ptr->count--;
-        }
-        else
-        {
-            object_ptr->count = 0U;
-            // do not call handler, when still running
-            if(g_timer_entered_handler == 0u)
-            {
-            	//g_timer_entered_handler++;
-            	XMC_SYSTIMER_lTimerHandler();
-            	g_timer_entered_handler--;
-            }
-        }
-    }
+/* checkID - Common ID check for valid and not running
+
+    Parameters  int Task ID to check
+
+    Return int  -1  invalid ID
+                 0  current task running
+                 1  Valid
+*/
+int CheckID( int ID )
+{
+if( ID < 0 || ID >= _MAX_TASKS )
+  return -1;
+if( ID == running )
+  return 0;
+return 1;
 }
 
-/** @ingroup Simple_System_Timer_App PublicFunc
- * @{
- */
 
-/*
- *  API for creating a new software Timer instance.
- */
-uint32_t XMC_SYSTIMER_CreateTimer
-(
-    uint32_t period,
-    XMC_SYSTIMER_MODE_t mode,
-    XMC_SYSTIMER_CALLBACK_t callback,
-    void*  args
-)
+/* setInterval - set the interval time in ms for a task
+
+   If task running just sets interval as next execution will be set at task end.
+
+   When task NOT running, also sets next execution time to now plus interval.
+
+    Parameters  int Task ID to check
+                unsigned int interval in ms
+
+    Return int  -2 invalid interval
+                -1 invalid ID
+                 0  task is running
+                > 0 task interval and execution time set
+*/
+int setInterval( int ID, uint32_t interval )
 {
-    uint32_t id = 0U;
-    uint32_t count = 0U;
-    uint32_t period_ratio = 0U;
+int i;
 
-    if (period == 0u)
-    {
-        id = 0U;
-    }
-    else
-    {
-        for (count = 0U; count < SYSTIMER_CFG_MAX_TMR; count++)
-        {
-            /* Check for free timer ID */
-            if (0U == (g_timer_tracker & (1U << count)))
-            {
-                /* If yes, assign ID to this timer */
-                g_timer_tracker |= (1U << count);
-                /* Initialize the timer as per input values */
-                g_timer_tbl[count].id     = count;
-                g_timer_tbl[count].mode   = mode;
-                g_timer_tbl[count].state  = XMC_SYSTIMER_STATE_STOPPED;
-                period_ratio = (uint32_t)period;
-                g_timer_tbl[count].count  = (period_ratio + HW_TIMER_ADDITIONAL_CNT);
-                g_timer_tbl[count].reload  = period_ratio;
-                g_timer_tbl[count].callback = callback;
-                g_timer_tbl[count].args = args;
-                g_timer_tbl[count].prev   = NULL;
-                g_timer_tbl[count].next   = NULL;
-                id = count + 1U;
-                break;
-            }
-        }
-
-    }
-
-    return (id);
+if( ( i = CheckID( ID ) ) < 0 )
+  return i;
+taskTable[ ID ].interval = interval;
+if( i != 0 )
+  {
+  taskTable[ ID ].next = millis( ) + interval + 1;
+  return 1;
+  }
+return 0;
 }
 
-/*
- *  API to start the software timer.
- */
-XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_StartTimer(uint32_t id)
+
+/* getInterval - get the interval time in ms for a task
+
+    Parameters  int Task ID to check
+                NO ID validity check
+
+    Return int  >= 0 Valid interval time
+*/
+uint32_t getInterval( int ID )
 {
-    XMC_SYSTIMER_STATUS_t status;
-    status = XMC_SYSTIMER_STATUS_FAILURE;
-
-    /* Check if timer is running */
-    if (XMC_SYSTIMER_STATE_STOPPED == g_timer_tbl[id - 1U].state)
-    {
-        g_timer_tbl[id - 1U].count = (g_timer_tbl[id - 1U].reload + HW_TIMER_ADDITIONAL_CNT);
-        /* set timer status as XMC_SYSTIMER_STATE_RUNNING */
-        g_timer_tbl[id - 1U].state = XMC_SYSTIMER_STATE_RUNNING;
-        /* Insert this timer into timer list */
-        XMC_SYSTIMER_lInsertTimerList((id - 1U));
-        status = XMC_SYSTIMER_STATUS_SUCCESS;
-    }
-
-    return (status);
+return taskTable[ ID ].interval;
 }
 
-/*
- *  API to stop the software timer.
- */
-XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_StopTimer(uint32_t id)
+
+/* setParam - set the param value for a task callback function
+
+   Parameters   int Task ID to check
+                int16_t param value
+
+   Return int   -1 invalid ID
+                 0  task is running
+                > 0 task interval and param value set
+*/
+int setParam( int ID, int16_t param )
 {
-    XMC_SYSTIMER_STATUS_t status;
-    status = XMC_SYSTIMER_STATUS_SUCCESS;
+int i;
 
-    if (XMC_SYSTIMER_STATE_NOT_INITIALIZED == g_timer_tbl[id - 1U].state)
-    {
-        status = XMC_SYSTIMER_STATUS_FAILURE;
-    }
-    else
-    {
-        /* Check whether Timer is in Stop state */
-        if (XMC_SYSTIMER_STATE_RUNNING == g_timer_tbl[id - 1U].state)
-        {
-            /* Set timer status as SYSTIMER_STATE_STOPPED */
-            g_timer_tbl[id - 1U].state = XMC_SYSTIMER_STATE_STOPPED;
-
-            /* remove Timer from node list */
-            XMC_SYSTIMER_lRemoveTimerList(id - 1U);
-
-        }
-    }
-
-    return (status);
+if( ( i = CheckID( ID ) ) < 0 )
+  return i;
+taskTable[ ID ].param = param;
+return i;
 }
 
-/*
- *  API to reinitialize the time interval and to start the timer.
- */
-XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_RestartTimer(uint32_t id, uint32_t microsec)
+
+/* getParam - get the param value for a task callback function
+
+    Parameters  int Task ID to get details of
+
+    Return int  -1 invalid ID or valid param
+                All other values assume the param value
+    */
+int16_t getParam( int ID )
 {
-    uint32_t period_ratio = 0U;
-    XMC_SYSTIMER_STATUS_t status;
-    status = XMC_SYSTIMER_STATUS_SUCCESS;
-
-    if (XMC_SYSTIMER_STATE_NOT_INITIALIZED == g_timer_tbl[id - 1U].state)
-    {
-        status = XMC_SYSTIMER_STATUS_FAILURE;
-    }
-    else
-    {
-        /* check whether timer is in run state */
-        if ( XMC_SYSTIMER_STATE_STOPPED != g_timer_tbl[id - 1U].state)
-        {
-            /* Stop the timer */
-            status = XMC_SYSTIMER_StopTimer(id);
-        }
-        if (XMC_SYSTIMER_STATUS_SUCCESS == status)
-        {
-            period_ratio = (uint32_t)microsec;
-            g_timer_tbl[id - 1U].reload = period_ratio;
-            /* Start the timer */
-            status = XMC_SYSTIMER_StartTimer(id);
-        }
-    }
-
-    return (status);
+int i;
+    
+if( ( i = CheckID( ID ) ) < 0 )
+  return i;
+return taskTable[ ID ].param;
 }
 
-/*
- *  Function to delete the Timer instance.
- */
-XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_DeleteTimer(uint32_t id)
+
+/* getTime - get next execution time in ms of a task
+
+    As value is unsigned long impossible to guarantee error codes
+    So if values listed below for errors check current millis() value
+    to see if could be real or error.
+
+    Parameters  int Task ID to check
+
+    Return      unsigned long of time (or could be errors)
+                0 could be execution time or error of invalid ID
+                1 could be execution time or error of NO interval
+*/
+unsigned long getTime( int ID )
 {
-    XMC_SYSTIMER_STATUS_t status;
-    status = XMC_SYSTIMER_STATUS_SUCCESS;
+int i;
 
-    /* Check whether Timer is in delete state */
-    if (XMC_SYSTIMER_STATE_NOT_INITIALIZED == g_timer_tbl[id - 1U].state)
-    {
-        status = XMC_SYSTIMER_STATUS_FAILURE;
-    }
-    else
-    {
-        if (XMC_SYSTIMER_STATE_STOPPED == g_timer_tbl[id - 1U].state)
-        {
-            /* Set timer status as SYSTIMER_STATE_NOT_INITIALIZED */
-            g_timer_tbl[id - 1U].state = XMC_SYSTIMER_STATE_NOT_INITIALIZED;
-            /* Release resource which are hold by this timer */
-            g_timer_tracker &= ~(1U << (id - 1U));
-        }
-        else
-        {
-            /* Yes, remove this timer from timer list during ISR execution */
-            g_timer_tbl[id - 1U].delete_swtmr = true;
-        }
-    }
-
-    return (status);
+if( ( i = CheckID( ID ) ) < 0 )
+  return 0;
+return taskTable[ ID ].next;
 }
 
-/*
- *  API to get the SysTick count.
- */
-uint32_t XMC_SYSTIMER_GetTickCount(void)
+
+/* getStatus - get task status even if running task
+
+    Parameters  int Task ID to get status for
+
+    Return int  -1  invalid ID
+               any other value Status (including other user errors -ve
+*/
+int16_t getStatus( int ID )
 {
-    return (g_systick_count);
+int i;
+
+// Check valid ID, not running and interval
+if( ( i = CheckID( ID ) ) < 0 )
+  return i;
+return taskTable[ ID ].status;
 }
 
-/*
- *  API to get the current state of software timer.
- */
-XMC_SYSTIMER_STATE_t XMC_SYSTIMER_GetTimerState(uint32_t id)
+
+/* StartTask - Start a task if not running and has interval set
+
+   Cannot start an already started task
+   
+   It is responsibility of the task to stop its task and any associated 
+   resources (GPIO/TWI/SPI etc).
+
+    Parameters  int Task ID to start
+
+    Return int  -3  Task already started
+                -2  No interval on task
+                -1  invalid ID
+                 0  current task running
+                > 0 Valid
+*/
+int StartTask( int ID )
 {
-    return (g_timer_tbl[id - 1U].state);
+int i;
+
+// Check valid ID, not running and interval
+if( ( i = CheckID( ID ) ) <= 0 )
+  return i;
+if( taskTable[ ID ].interval == 0 )
+  return -2;
+if( taskTable[ ID ].status  > 0 )
+  return -3;
+// Start task
+taskTable[ ID ].next = old_ms + taskTable[ ID ].interval;
+taskTable[ ID ].status = 1;
+return 1;
+}
+
+
+/* FindID - Find ID for FIRST task with matching function address in Task table
+
+   Scans task table to find a matching function address and return the ID
+   NOTE stops at FIRST match.
+   
+    Parameters  int Task ID to Stop
+
+    Return int  < 0 Invalid task address
+                > 0 Valid and stopped
+*/
+//int (* tasks[_MAX_TASKS])( int, int )
+int FindID( int(*  ptr)( int, int16_t ) )
+{
+int i;
+
+if( ptr == NULL )
+  return -1;
+for( i = 0; i < _MAX_TASKS; i++ )
+   if( tasks[ i ] == ptr )
+     break;
+if( i == _MAX_TASKS )
+  return -2;
+return i;
 }
 
 //****************************************************************************

--- a/arm/cores/wiring_time.h
+++ b/arm/cores/wiring_time.h
@@ -25,182 +25,180 @@ extern "C" {
 //****************************************************************************
 // @Defines
 //****************************************************************************
+/**< SysTick interval in microseconds */
+#define SYSTIMER_TICK_PERIOD_US  (1000U)
+/**< value for Systick counts per ms **/
+#define SYSTICK_MS  ( F_CPU / SYSTIMER_TICK_PERIOD_US )
+/**< value for Systick counts per us **/
+#define SYSTICK_US  ( SYSTICK_MS / SYSTIMER_TICK_PERIOD_US )
+
 #if ((UC_FAMILY == XMC4) && (F_CPU == 144000000U))
-
-#define NOPS_FOR_USEC()    asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop");asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop")
-							
+// 142 NOPS
+#define NOPS_FOR_USEC() asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+                        asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+                        asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+                        asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+                        asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop")
 #elif ((UC_FAMILY == XMC1) && (F_CPU == 32000000U))
-
-#define NOPS_FOR_USEC()    asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
-							asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); asm volatile("nop")
+// 16 NOPS
+#define NOPS_FOR_USEC() asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop"); asm volatile("nop"); asm volatile("nop"); \
+						asm volatile("nop")
 #else
-#error wiring_time: NOPS_FOR_USEC not defined 
+#error wiring_time: NOPS_FOR_USEC not defined
 #endif
 
 //****************************************************************************
 // @Typedefs
 //****************************************************************************
-    typedef void (*XMC_SYSTIMER_CALLBACK_t)(void* args);
+/* Structures  for task details next run, status etc.. */
+struct TaskList {
+                uint32_t    next;       // next execution time in ms
+                uint32_t    interval;   // interval between schedule starts in ms
+                int16_t     param;      // User defined parameter
+                int16_t     status;     // current task status 0 stopped,
+                                        // -ve stopped with error,
+                                        // > 0 user status (and active)
+                };
 
-    typedef enum XMC_SYSTIMER_STATUS
-    {
-        XMC_SYSTIMER_STATUS_SUCCESS = 0U, /**< Status Success if initialization is successful */
-        XMC_SYSTIMER_STATUS_FAILURE  /**< Status Failure if initialization is failed */
-    } XMC_SYSTIMER_STATUS_t;
-
-    typedef enum XMC_SYSTIMER_MODE
-    {
-        XMC_SYSTIMER_MODE_ONE_SHOT = 0U, /**< timer type is one shot */
-        XMC_SYSTIMER_MODE_PERIODIC /**< timer type is periodic */
-    } XMC_SYSTIMER_MODE_t;
-
-    typedef enum XMC_SYSTIMER_STATE
-    {
-        XMC_SYSTIMER_STATE_NOT_INITIALIZED = 0U, /**< The timer is in uninitialized state */
-        XMC_SYSTIMER_STATE_RUNNING, /**< The timer is in running state */
-        XMC_SYSTIMER_STATE_STOPPED /**< The timer is in stop state */
-    } XMC_SYSTIMER_STATE_t;
+/* SysTick counter */
+extern volatile uint32_t g_systick_count;
 
 //****************************************************************************
 // @External Prototypes
 //****************************************************************************
+/*
+ * \brief Initialize the time module.
+ */
+extern void wiring_time_init( void );
 
-    /*
-     * \brief Initialize the time module.
-     */
-    extern void wiring_time_init(void);
+/*
+ * \brief Returns the number of milliseconds since the Arduino board began running the current program.
+ *
+ * This number will overflow (go back to zero), after approximately 50 days.
+ *
+ * \return Number of milliseconds since the program started (uint32_t)
+ */
+static inline uint32_t  millis( void ) __attribute__(( always_inline ));
+static inline uint32_t  millis( void )
+{
+return ( g_systick_count );
+}
 
-    /*
-     * \brief Returns the number of milliseconds since the Arduino board began running the current program.
-     *
-     * This number will overflow (go back to zero), after approximately 50 days.
-     *
-     * \return Number of milliseconds since the program started (uint32_t)
-     */
-    extern uint32_t millis(void) ;
 
-    /*
-     * \brief Returns the number of microseconds since the Arduino board began running the current program.
-     *
-     * This number will overflow (go back to zero), after approximately 70 minutes. On 16 MHz Arduino boards
-     * (e.g. Duemilanove and Nano), this function has a resolution of four microseconds (i.e. the value returned is
-     * always a multiple of four). On 8 MHz Arduino boards (e.g. the LilyPad), this function has a resolution
-     * of eight microseconds.
-     *
-     * \note There are 1,000 microseconds in a millisecond and 1,000,000 microseconds in a second.
-     */
-    extern uint32_t micros(void) ;
+/*
+ * \brief Returns the number of microseconds since the Arduino board began running the current program.
+ *
+ * This number will overflow (go back to zero), after approximately 70 minutes. On 16 MHz Arduino
+ * boards (e.g. Duemilanove and Nano), this function has a resolution of four microseconds (i.e.
+ * the value returned is always a multiple of four). On 8 MHz Arduino boards (e.g. the LilyPad), this
+ * function has a resolution of eight microseconds.
+ *
+ * \note There are 1,000 microseconds in a millisecond and 1,000,000 microseconds in a second.
 
-    /*
-     * \brief Pauses the program for the amount of time (in miliseconds) specified as parameter.
-     * (There are 1000 milliseconds in a second.)
-     *
-     * \param dwMs the number of milliseconds to pause (uint32_t)
-     */
-    extern void delay(uint32_t dwMs) ;
+   get micro seconds since power up 
+   Read milli seconds (in microseconds) and convert Systick counter to microseconds to add to it 
+   remember SysTick->VAL counts DOWN to zero */
+static inline uint32_t  micros( void ) __attribute__(( always_inline ));
+static inline uint32_t  micros( void )
+{
+return ( ( g_systick_count * SYSTIMER_TICK_PERIOD_US )
+            + ( ( SYSTICK_MS - SysTick->VAL ) / SYSTICK_US ) );
+}
 
-    /*
-     * \brief Pauses the program for the amount of time (in microseconds) specified as parameter.
-     *
-     * \param dwUs the number of microseconds to pause (uint32_t)
-     */
-    static inline void delayMicroseconds(uint32_t) __attribute__((always_inline));
-    static inline void delayMicroseconds(uint32_t usec)
+
+/*
+ * \brief Pauses the program for the amount of time (in milliseconds) specified as parameter.
+ * (There are 1000 milliseconds in a second.)
+ *
+ * \param dwMs the number of milliseconds to pause (uint32_t)
+ */
+extern void delay( uint32_t dwMs );
+
+/*
+ * \brief Pauses the program for the amount of time (in microseconds) specified as parameter.
+ *
+ *  DISABLES all interrupts during this time
+ *
+ * \param dwUs the number of microseconds to pause (uint32_t)
+ */
+static inline void delayMicroseconds( uint32_t ) __attribute__(( always_inline ));
+static inline void delayMicroseconds( uint32_t usec )
+{
+if( usec == 0 )
+  return;
+else
     {
+    uint32_t number_of_cycles = usec;
 
-        if (usec == 0)
+    noInterrupts( );
+    // NOP loop to generate delay
+    while( number_of_cycles )
         {
-            return;
+        NOPS_FOR_USEC( );
+        number_of_cycles--;
         }
-        else
-        {
-            uint32_t number_of_cycles = usec;
-			
-			noInterrupts();
-            // NOP loop to gnerate delay
-            while (number_of_cycles)
-            {
-				NOPS_FOR_USEC();
-                number_of_cycles--;
-            }
-			interrupts();
-        }
+    interrupts( );
     }
-    /*
-     * @brief Creates a new software timer.
-     * @param period  timer period value in microseconds. Range: (SYSTIMER_TICK_PERIOD_US) to pow(2,32).
-     * @param mode  Mode of timer(ONE_SHOT/PERIODIC). Refer @ref XMC_SYSTIMER_MODE_t for details.
-     * @param callback  Call back function of the timer(No Macros are allowed).
-     * @param args  Call back function parameter.
-     */
-    uint32_t XMC_SYSTIMER_CreateTimer
-    (
-        uint32_t period,
-        XMC_SYSTIMER_MODE_t mode,
-        XMC_SYSTIMER_CALLBACK_t callback,
-        void*  args
-    );
+}
 
-    /*
-     * @brief Starts the software timer.
-     * @param id  timer ID obtained from SYSTIMER_CreateTimer. Range : 1 to 16
-     * @return XMC_SYSTIMER_STATUS_t APP status. Refer @ref XMC_SYSTIMER_STATUS_t for details.
-     */
-    XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_StartTimer(uint32_t id);
-
-    /*
-     * @brief Stops the software timer.
-     * @param id  timer ID obtained from SYSTIMER_CreateTimer. Range : 1 to 16
-     * @return XMC_SYSTIMER_STATUS_t APP status. Refer @ref XMC_SYSTIMER_STATUS_t for details.
-     */
-    XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_StopTimer(uint32_t id);
-
-    /*
-     * @brief Function to modify the time interval and restart the timer for the new time interval.<br>
-     * @param id ID of already created system timer. Range : 1 to 16
-     * @param microsec new time interval. Range: (SYSTIMER_TICK_PERIOD_US) to pow(2,32).
-     * @return XMC_SYSTIMER_STATUS_t APP status. Refer @ref XMC_SYSTIMER_STATUS_t for details.
-     */
-    XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_RestartTimer(uint32_t id, uint32_t microsec);
-
-    /*
-     * @brief Deletes the software timer from the timer list.
-     * @param id  timer ID obtained from SYSTIMER_CreateTimer. Range : 1 to 16
-     * @return XMC_SYSTIMER_STATUS_t APP status. Refer @ref XMC_SYSTIMER_STATUS_t for details.
-     */
-    XMC_SYSTIMER_STATUS_t XMC_SYSTIMER_DeleteTimer(uint32_t id);
-
-    /*
-     * @brief Gives the SysTick count.
-     * @return  uint32_t  returns SysTick count. Range: 0 to pow(2,32).
-     */
-    uint32_t XMC_SYSTIMER_GetTickCount(void);
-
-    /*
-     * @brief Gives the current state of software timer.
-     * @param id  timer ID obtained from SYSTIMER_CreateTimer. Range : 1 to 16
-     * @return XMC_SYSTIMER_STATE_t Software timer state. Refer @ref XMC_SYSTIMER_STATE_t for details.
-     */
-    XMC_SYSTIMER_STATE_t XMC_SYSTIMER_GetTimerState(uint32_t id);
+extern int setInterval( int, uint32_t );
+extern uint32_t getInterval( int );
+extern int setParam( int, int16_t );
+extern int16_t getParam( int );
+extern uint32_t getTime( int );
+extern int16_t getStatus( int );
+extern int StartTask( int );
+extern int FindID( int(*  )( int, int16_t ) );
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif /* WIRING_TIME_H_ */

--- a/arm/cores/xmc_lib/XMCLib/inc/xmc_device.h
+++ b/arm/cores/xmc_lib/XMCLib/inc/xmc_device.h
@@ -1,6 +1,6 @@
 /**
  * @file xmc_device.h
- * @date 2016-07-21
+ * @date 2018-03-08
  *
  * @cond
   *********************************************************************************************************************
@@ -53,6 +53,11 @@
  *             XMC1302_T028x0016, XMC1402_T038x0032, XMC1402_T038x0064, XMC1402_T038x0128, 
  *             XMC1403_Q040x0064, XMC1403_Q040x0128, XMC1403_Q040x0200, XMC1402_T038x0200
  *             XMC1402_Q040x0200, XMC1402_Q048x0200, XMC1201_T028x0032
+ *
+ * 2018-03-08:
+ *      - Added defines for XMC1 and XMC47 and XMC48 series to give RAM totals in
+ *        UC_RAm and UC_ALL_RAM
+ *
  * @endcond 
  *
  */
@@ -124,6 +129,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   BGA196
 #define UC_FLASH     (2048UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (352UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -134,6 +141,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (2048UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (352UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -144,6 +153,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (2048UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (352UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -154,6 +165,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   BGA196
 #define UC_FLASH     (1536UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -164,6 +177,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (1536UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -174,6 +189,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (1536UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -184,6 +201,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   BGA196
 #define UC_FLASH     (1024UL)
+#define UC_RAM       (72UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -194,6 +213,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (1024UL)
+#define UC_RAM       (72UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -204,6 +225,8 @@
 #define UC_DEVICE    XMC4800
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (1024UL)
+#define UC_RAM       (72UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -214,6 +237,8 @@
 #define UC_DEVICE    XMC4700
 #define UC_PACKAGE   BGA196
 #define UC_FLASH     (2048UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (352UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -224,6 +249,8 @@
 #define UC_DEVICE    XMC4700
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (2048UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (352UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -234,6 +261,8 @@
 #define UC_DEVICE    XMC4700
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (2048UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (352UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -244,6 +273,8 @@
 #define UC_DEVICE    XMC4700
 #define UC_PACKAGE   BGA196
 #define UC_FLASH     (1536UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -254,6 +285,8 @@
 #define UC_DEVICE    XMC4700
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (1536UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -264,6 +297,8 @@
 #define UC_DEVICE    XMC4700
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (1536UL)
+#define UC_RAM       (96UL)
+#define UC_ALL_RAM   (276UL)
 #define MULTICAN_PLUS
 #define CCU4V2
 #define CCU8V2
@@ -274,6 +309,8 @@
 #define UC_DEVICE    XMC4500
 #define UC_PACKAGE   BGA144
 #define UC_FLASH     (1024UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (80UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -283,6 +320,8 @@
 #define UC_DEVICE    XMC4500
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (1024UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (80UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -292,6 +331,8 @@
 #define UC_DEVICE    XMC4500
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (1024UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (80UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -301,6 +342,8 @@
 #define UC_DEVICE    XMC4500
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (768UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (80UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -310,6 +353,8 @@
 #define UC_DEVICE    XMC4500
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (768UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (80UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -319,6 +364,8 @@
 #define UC_DEVICE    XMC4502
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (768UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (80UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -328,6 +375,8 @@
 #define UC_DEVICE    XMC4504
 #define UC_PACKAGE   LQFP100
 #define UC_FLASH     (512UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (64UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -337,6 +386,8 @@
 #define UC_DEVICE    XMC4504
 #define UC_PACKAGE   LQFP144
 #define UC_FLASH     (512UL)
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (64UL)
 #define CCU4V1
 #define CCU8V1
 
@@ -913,6 +964,8 @@
 #define UC_DEVICE    XMC1301
 #define UC_PACKAGE   TSSOP38
 #define UC_FLASH     (16UL)
+#define UC_RAM       (16UL)
+#define UC_ALL_RAM   (16UL)
 #define CCU4V2
 #define CCU8V2
 
@@ -1028,6 +1081,8 @@
 #define UC_DEVICE    XMC1302
 #define UC_PACKAGE   TSSOP38
 #define UC_FLASH     (64UL)
+#define UC_RAM       (16UL)
+#define UC_ALL_RAM   (16UL)
 #define CCU4V2
 #define CCU8V2
 
@@ -1454,6 +1509,35 @@
 #else
 #error "xmc_device.h: device not supported"
 #endif 	    
+#if UC_FAMILY == XMC1
+#define UC_RAM       (16UL)
+#define UC_ALL_RAM   (16UL)
+#endif
+
+#if UC_FAMILY == XMC41
+#define UC_RAM       (8UL)
+#define UC_ALL_RAM   (20UL)
+#endif
+
+#if UC_FAMILY == XMC42
+#define UC_RAM       (16UL)
+#define UC_ALL_RAM   (40UL)
+#endif
+
+#if UC_FAMILY == XMC43
+#define UC_RAM       (64UL)
+#define UC_ALL_RAM   (128UL)
+#endif
+
+#if UC_FAMILY == XMC44
+#define UC_RAM       (16UL)
+#define UC_ALL_RAM   (80UL)
+#endif
+
+#if UC_FAMILY == XMC45
+#define UC_RAM       (8UL)
+#define UC_ALL_RAM   (20UL)
+#endif
 
 #if UC_SERIES == XMC45
 #include "XMC4500.h"

--- a/arm/platform.txt
+++ b/arm/platform.txt
@@ -90,10 +90,10 @@ recipe.output.tmp_file={build.project_name}.bin
 recipe.output.save_file={build.project_name}.{build.variant}.bin
 
 ## Compute size
-recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"
-recipe.size.regex=\.text\s+([0-9]+).*
-
-
+recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A --common "{build.path}/{build.project_name}.elf"
+recipe.size.regex=^(\.text|\.eh_frame)\s+([0-9]+).*
+# recipe to show SRAM size used
+recipe.size.regex.data=^(?:\.data|\.VENEER_Code|\.ram_code|\.bss|\.no_init|\Stack)\s+([0-9]+).*
 
 # ------------------------------
 


### PR DESCRIPTION
Series of commits that

1. Correct Flash total to closer value after compile message
2. Gives A RAM estimate after compile that is at least 16 bytes short due to memory holes not counted, includes all sections even stack which could be 1024 or 2048 bytes depending on XMCLIB version.
3. Rewritten Systick 1ms timer event scheduler that has been tested on 4 Tones and delay (ms) uses hard coded arrays for schedule list and proven methods for scheduling co-operatively, approximate timings is from 5 micro seconds to execute when no tasks waiting and around 20 micro seconds when 5 tasks to be processed. This is on XMC1100. Allows for 4 tones on XMC1 series and 16 on XMC4 series.

Tone had to be modified to use the new scheduler.

Example 4 tones using on board LEDs available on request

4. Add defines for UC_RAM and UC_ALL_RAM for by CPU RAM sizes