### PR TITLE
Fix build when i2c is enabled.

### DIFF
--- a/arm/libraries/SPI/src/HW_SPI.cpp
+++ b/arm/libraries/SPI/src/HW_SPI.cpp
@@ -124,18 +124,18 @@ void SPIClass::end()
 	{
 		XMC_GPIO_CONFIG_t default_input_port_config = {
             .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
+            .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
 #if UC_FAMILY == XMC1
-            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
+            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD
 #endif
-            .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH
         };
 		
 		XMC_GPIO_CONFIG_t default_output_port_config = {
             .mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL,
+            .output_level = XMC_GPIO_OUTPUT_LEVEL_LOW,
 #if UC_FAMILY == XMC1
-            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
+            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD
 #endif
-            .output_level = XMC_GPIO_OUTPUT_LEVEL_LOW
         };
 
 		XMC_SPI_CH_Stop(XMC_SPI_config->channel);

--- a/arm/libraries/Wire/src/Wire.cpp
+++ b/arm/libraries/Wire/src/Wire.cpp
@@ -169,10 +169,10 @@ void TwoWire::end(void)
         
         XMC_GPIO_CONFIG_t default_output_port_config = {
             .mode = XMC_GPIO_MODE_OUTPUT_OPEN_DRAIN,
+            .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
 #if UC_FAMILY == XMC1
-            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD,
+            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD
 #endif
-            .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH
         };
 
 		XMC_I2C_CH_Stop(XMC_I2C_config->channel);


### PR DESCRIPTION
gcc version 5.4.1 20160919 (release) [ARM/embedded-5-branch revision 240496] (GNU Tools for ARM Embedded Processors)  (downloaded from https://github.com/Infineon/Assets/releases/tag/current)

Without this fix, compiling this code 
```
#include <Arduino.h>
#include <Wire.h>

void setup()
{
  
}

void loop()
{
  
}

```
Ends with following error

```
Processing xmc1100_xmc2go (platform: infineonxmc; board: xmc1100_xmc2go; framework: arduino)
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
PLATFORM: Infineon XMC > XMC1100 XMC2Go
SYSTEM: 32MHz 64KB RAM (64KB Flash)
Library Dependency Finder -> http://bit.ly/configure-pio-ldf
LDF MODES: FINDER(chain) COMPATIBILITY(soft)
Collected 8 compatible libraries
Scanning dependencies...
Dependency Graph
|-- <Wire> 1.1
|   |-- <SPI> 1.1
Compiling .pioenvs/xmc1100_xmc2go/libe9a/SPI/HW_SPI.cpp.o
Compiling .pioenvs/xmc1100_xmc2go/libe79/Wire/Wire.cpp.o
/home/pablo/.platformio/packages/framework-arduinoxmc/libraries/SPI/src/HW_SPI.cpp: In member function 'void SPIClass::end()':
/home/pablo/.platformio/packages/framework-arduinoxmc/libraries/SPI/src/HW_SPI.cpp:131:9: sorry, unimplemented: non-trivial designated initializers not supported
};
^
/home/pablo/.platformio/packages/framework-arduinoxmc/libraries/SPI/src/HW_SPI.cpp:131:9: sorry, unimplemented: non-trivial designated initializers not supported
/home/pablo/.platformio/packages/framework-arduinoxmc/libraries/SPI/src/HW_SPI.cpp:139:9: sorry, unimplemented: non-trivial designated initializers not supported
};
^
/home/pablo/.platformio/packages/framework-arduinoxmc/libraries/SPI/src/HW_SPI.cpp:139:9: sorry, unimplemented: non-trivial designated initializers not supported
/home/pablo/.platformio/packages/framework-arduinoxmc/libraries/Wire/src/Wire.cpp: In member function 'void TwoWire::end()':
/home/pablo/.platformio/packages/framework-arduinoxmc/libraries/Wire/src/Wire.cpp:176:9: sorry, unimplemented: non-trivial designated initializers not supported
};
^
/home/pablo/.platformio/packages/framework-arduinoxmc/libraries/Wire/src/Wire.cpp:176:9: sorry, unimplemented: non-trivial designated initializers not supported
*** [.pioenvs/xmc1100_xmc2go/libe9a/SPI/HW_SPI.cpp.o] Error 1
*** [.pioenvs/xmc1100_xmc2go/libe79/Wire/Wire.cpp.o] Error 1
```