### PR TITLE
Fixes to XMC2GO pinout, analog functions and PWM

### DIFF
--- a/arm/cores/wiring_analog.c
+++ b/arm/cores/wiring_analog.c
@@ -18,7 +18,14 @@
   Copyright (c) 2018 Infineon Technologies AG
   This file has been modified for the XMC microcontroller series.
 */
-
+/* Paul Carpenter  March-2019
+   Several fixes to remove redundant code
+   Fix prescaler bug for CCU8 in analogWriteFrequency
+   analogWrite - Improvements, extra safety and more documentation
+   analogRead - Change return to 0xFFFFFFFF (an invalid value) for invalid channel
+   wiring_analog_init - Add dummy reading so background scanning starts on ALL
+                possible channels meaning first user reading will be valid
+*/
 //****************************************************************************
 // @Project Includes
 //****************************************************************************
@@ -59,7 +66,7 @@ memset( &vadc_group_config, 0, sizeof( XMC_VADC_GROUP_CONFIG_t ) );
 vadc_group_config.class0.conversion_mode_standard = XMC_VADC_CONVMODE_12BIT;
 vadc_group_config.class1.conversion_mode_standard = XMC_VADC_CONVMODE_12BIT;
 
-/*Initialize Group*/
+/* Initialize Group */
 XMC_VADC_GROUP_Init( VADC_G0, &vadc_group_config );
 XMC_VADC_GROUP_Init( VADC_G1, &vadc_group_config );
 
@@ -68,7 +75,7 @@ XMC_VADC_GROUP_SetPowerMode( VADC_G0, XMC_VADC_GROUP_POWERMODE_NORMAL );
 XMC_VADC_GROUP_SetPowerMode( VADC_G1, XMC_VADC_GROUP_POWERMODE_NORMAL );
 
 #if(XMC_VADC_MAXIMUM_NUM_GROUPS > 2)
-/*Initialize Group*/
+/* Initialize Group */
 XMC_VADC_GROUP_Init( VADC_G2, &vadc_group_config );
 
 /* Switch on the converter of the Group*/
@@ -77,17 +84,28 @@ XMC_VADC_GROUP_SetPowerMode( VADC_G2, XMC_VADC_GROUP_POWERMODE_NORMAL );
 
 #endif
 /* Calibrate the VADC. Make sure you do this after all used VADC groups
-* are set to normal operation mode. */
+   are set to normal operation mode. */
 XMC_VADC_GLOBAL_StartupCalibration( VADC );
 
 /* Initialize the background source hardware. The gating mode is set to
-* ignore to pass external triggers unconditionally.*/
+   ignore to pass external triggers unconditionally.*/
 XMC_VADC_GLOBAL_BackgroundInit( VADC, &vadc_background_config );
+
+/* PC Mar-2019
+   Dummy read of ALL analogue inputs to ensure ALL analogue channels are
+   started in background scanning mode, otherwise first readings at least
+   will always be zero on reading an analogue input. */
+for( uint8_t chan = 0; chan < NUM_ANALOG_INPUTS; chan++ )
+   analogRead( chan );
 
 //Additional Initialization of DAC starting here
 }
 
 
+/* Set the resolution of analogRead return values in number of bits. 
+    Default is 10 bits (range from 0 to 1023)
+    Maximum is 12 bits (range from 0 to 4095)
+*/
 void analogReadResolution( uint8_t res )
 {
 if (res > ADC_MAX_READ_RESOLUTION)
@@ -96,12 +114,18 @@ _readResolution = res;
 }
 
 
+/* Set the resolution of analogWrite parameters in number of bits. 
+
+  Default (minimum) is 8 bits (range from 0 to 255).
+  Maximum is 16 bits (range 0 to 65535)
+*/
 void analogWriteResolution( uint8_t res )
 {
 if (res > ANALOG_MAX_WRITE_RESOLUTION)
     res = ANALOG_MAX_WRITE_RESOLUTION;
 _writeResolution = res;
 }
+
 
 // This appears to be a dummy function and variable not used elsewhere
 uint8_t analog_reference = DEFAULT;
@@ -111,13 +135,12 @@ void analogReference( uint8_t ulMode )
 analog_reference = ulMode;
 }
 
-// analogRead takes parameter of ADC channel number
-// return 0 for invalid channel
-// Would prefer a return of 0xFFFFFFFF to be obvious in code/debug when wrong
-// instead of valid value as it has been done
+
+/* analogRead takes parameter of ADC channel number
+        return 0xFFFFFFFF for invalid channel */
 uint32_t analogRead( uint8_t channel )
 {
-uint32_t value = 0;
+uint32_t value = 0xFFFFFFFF;
 
 if( channel < NUM_ANALOG_INPUTS )
   {
@@ -140,7 +163,7 @@ if( channel < NUM_ANALOG_INPUTS )
     XMC_VADC_GROUP_ResultInit( adc->group, adc->result_reg_num, &vadc_gobal_result_config );
     /* Add channel into the Background Request Source Channel Select Register */
     XMC_VADC_GLOBAL_BackgroundAddChannelToSequence( VADC, (uint32_t)adc->group_num,
-                                                            (uint32_t)adc->channel_num );
+                                                          (uint32_t)adc->channel_num );
     }
   /* Start conversion manually using load event trigger*/
   XMC_VADC_GLOBAL_BackgroundTriggerConversion( VADC );
@@ -159,13 +182,14 @@ if( channel < NUM_ANALOG_INPUTS )
   return ( ( value & VADC_GLOBRES_RESULT_Msk) >> ( ADC_MAX_READ_RESOLUTION - _readResolution ) );
   }
 else
-  return 0;
+  return 0xFFFFFFFF;
 }
 
 
-/* Helper function for analogWrite to scan mapping tables to determine
-   for a given pin which PWM4, PWM8 or DAC channel to use
-   Returns valid channel or -1 for not listed
+/* Helper function for analogWrite and setAnalogWriteFrequency to scan 
+   mapping tables to determine for a given pin which PWM4, PWM8 or DAC
+   channel to use
+   Returns valid channel index or -1 for not listed
    reading first column as 255 denotes end of table
    See pins_arduino.h for table layout
 */
@@ -186,6 +210,19 @@ return -1;
 }
 
 
+/* Writes an analogue value to a DAC or PWM wave to a pin.
+     DAC is straight write to DAC (if present on that pin)
+
+     PWM depends on analogWriteResolution()
+     Effect of value is the duty cycle for PWM output to be HIGH
+     Valid values are
+                Write resolution (bits)
+     Value      8      10      12      16
+     OFF        0      0       0       0
+     ON always  255    1023    4095    65535
+
+     Values in between these values vary the duty cycle
+ */
 void analogWrite( uint8_t pin, uint16_t value )
 {
 uint32_t compare_reg = 0;
@@ -212,7 +249,7 @@ if( ( resource = scan_map_table( mapping_pin_PWM4, pin ) ) >= 0 )
         }
 
     if( value != 0 )
-        compare_reg  = ( ( ( value + 1 ) * pwm4->period_timer_val ) >> _writeResolution );
+        compare_reg  = ( ( value + 1 ) * ( pwm4->period_timer_val + 1 ) ) >> _writeResolution;
 
     XMC_CCU4_SLICE_SetTimerCompareMatch( pwm4->slice, compare_reg );
     XMC_CCU4_EnableShadowTransfer( pwm4->ccu, ( CCU4_GCSS_S0SE_Msk << ( 4 * pwm4->slice_num ) ) );
@@ -245,7 +282,7 @@ else
         }
 
     if( value != 0 )
-        compare_reg  = ( ( ( value + 1 ) * pwm8->period_timer_val ) >> _writeResolution );
+        compare_reg  = ( ( value + 1 ) * ( pwm8->period_timer_val + 1 ) ) >> _writeResolution;
 
     XMC_CCU8_SLICE_SetTimerCompareMatch( pwm8->slice, pwm8->slice_channel, compare_reg );
     XMC_CCU8_EnableShadowTransfer( pwm8->ccu, CCU8_GCSS_S0SE_Msk << ( 4 * pwm8->slice_num ) );
@@ -270,58 +307,66 @@ else
 }
 
 
+/* Sets the frequency for analogWrite PWM.
+
+   Parameters   pin
+                frequency in Hz
+
+   Returns -1 for invalid pin or frequency
+            0 to F for valid prescaler set
+*/
 extern int16_t setAnalogWriteFrequency( uint8_t pin, uint32_t frequency )
 {
-	int16_t ret = -1;
-	if(frequency < PCLK)
-	{
+    int16_t ret = -1;
     uint16_t prescaler = 0U;
-		do
-		{
-			if( frequency > (PCLK / ( ( 1U << prescaler ) * 65536U )) )
-			{
-				break;
-			}
-      prescaler++;
-		}while(prescaler <= 16);
+    int16_t resource;
+    uint16_t period;
+
+    if( frequency < PCLK )
+    {
+      do
+        {
+        if( frequency > ( PCLK / ( ( 1U << prescaler ) * 65536U ) ) )
+          break;
+        prescaler++;
+        }
+      while( prescaler < 15 );      // Prescaler must never be > 15
+
+    // Calculate 16 bit timer end value
+    period = ( PCLK / ( ( 1U << prescaler )  * frequency ) ) - 1;
     
-    int16_t resource;		
     if ( ( resource = scan_map_table( mapping_pin_PWM4, pin ) ) >= 0 )
-		{
-			uint8_t pwm4_num = resource;
-			XMC_PWM4_t *pwm4 = &mapping_pwm4[pwm4_num];
-					
-			pwm4->prescaler = prescaler;
-			pwm4->period_timer_val = PCLK / ( ( 1U << prescaler )  * frequency) - 1;
-			
-			if(pwm4->enabled == ENABLED)
-			{
-				// Disable pwm output
-				pwm4->enabled = DISABLED;
-				XMC_CCU4_SLICE_StartTimer(pwm4->slice);
-			}	
-			ret = 0;
-		}
+        {
+            XMC_PWM4_t *pwm4 = &mapping_pwm4[ resource ];
+
+            pwm4->prescaler = prescaler;
+            pwm4->period_timer_val = period;
+            if( pwm4->enabled == ENABLED )
+            {
+                // Disable pwm output
+                pwm4->enabled = DISABLED;
+                XMC_CCU4_SLICE_StartTimer( pwm4->slice );
+            }
+            ret = prescaler;
+        }
 #ifdef CCU8V2
-		else if ( (resource = scan_map_table( mapping_pin_PWM8, pin ) ) >= 0 )
-		{
-			uint8_t pwm8_num = resource;
-			XMC_PWM8_t *pwm8 = &mapping_pwm8[pwm8_num];
-					
-			pwm8->prescaler = prescaler - 1;
-			pwm8->period_timer_val = PCLK / ( ( 1U << prescaler ) * frequency) - 1;
-			
-			if(pwm8->enabled == ENABLED)
-			{
-				// Disable pwm output
-				pwm8->enabled = DISABLED;
-				XMC_CCU8_SLICE_StartTimer(pwm8->slice);
-			}
-			ret = 0;
-		}
+        else if ( ( resource = scan_map_table( mapping_pin_PWM8, pin ) ) >= 0 )
+        {
+            XMC_PWM8_t *pwm8 = &mapping_pwm8[ resource ];
+
+            pwm8->prescaler = prescaler;
+            pwm8->period_timer_val = period;
+            if( pwm8->enabled == ENABLED )
+            {
+                // Disable pwm output
+                pwm8->enabled = DISABLED;
+                XMC_CCU8_SLICE_StartTimer( pwm8->slice );
+            }
+            ret = prescaler;
+        }
 #endif
-	}
-	return ret;
+    }
+    return ret;
 }
 //****************************************************************************
 //                                 END OF FILE

--- a/arm/cores/wiring_analog.h
+++ b/arm/cores/wiring_analog.h
@@ -40,7 +40,18 @@ extern "C" {
     extern void analogReference( uint8_t ulMode ) ;
 
     /*
-     * \brief Writes an analog value (PWM wave) to a pin.
+     * \brief Writes an analog value to a DAC or PWM wave to a pin.
+     *        DAC is straight write to DAC (if present on that pin)
+     *
+     *        PWM depends on analogWriteResolution()
+     *        Effect of value is the duty cycle for PWM output to be HIGH
+     *        Valid values are
+     *                   Write resolution (bits)
+     *        Value      8      10      12      16
+     *        OFF        0      0       0       0
+     *        ON always  255    1023    4095    65535
+     *
+     *        Values in between these values vary the duty cycle
      *
      * \param pin
      * \param value
@@ -50,7 +61,9 @@ extern "C" {
 	/*
      * \brief Sets the frequency for analogWrite PWM.
 	 * 
-	 * \note Default value is 490 Hz
+     *    Returns -1 for invalid pin or frequency
+     *             0 to F for valid prescaler set
+ 	 * \note Default value is 490 Hz
      *
      * \param pin
      * \param frequency in Hz
@@ -67,14 +80,16 @@ extern "C" {
     extern uint32_t analogRead( uint8_t pin ) ;
 
     /*
-     * \brief Set the resolution of analogRead return values. Default is 10 bits (range from 0 to 1023).
+     * \brief Set the resolution of analogRead return values in number of bits. Default is 10 bits (range from 0 to 1023).
      *
      * \param res
      */
     extern void analogReadResolution(uint8_t res);
 
     /*
-     * \brief Set the resolution of analogWrite parameters. Default is 8 bits (range from 0 to 255).
+     * \brief Set the resolution of analogWrite parameters in number of bits. 
+     *  Default (minimum) is 8 bits (range from 0 to 255).
+     *  Maximum is 16 bits (range 0 to 65535)
      *
      * \param res
      */

--- a/arm/variants/XMC1100/config/XMC1100_Boot_Kit/pins_arduino.h
+++ b/arm/variants/XMC1100/config/XMC1100_Boot_Kit/pins_arduino.h
@@ -37,8 +37,7 @@
 /* On board LED is ON when digital output is 0, LOW, False, OFF */
 #define  XMC_LED_ON         0
 
-//#define NUM_DIGITAL_PINS    18
-#define NUM_ANALOG_INPUTS   6
+#define NUM_ANALOG_INPUTS   8
 #define NUM_PWM             4
 #define NUM_LEDS            7
 #define NUM_INTERRUPT       2
@@ -75,6 +74,8 @@
 #define A3   3
 #define A4   4
 #define A5   5
+#define A6   6
+#define A7   7
 
 #define AD_AUX_1    24  // AD_AUX
 #define AD_AUX_2    25  // AD_AUX
@@ -125,8 +126,8 @@ const XMC_PORT_PIN_t mapping_port_pin[] =
     /* 12  */   {XMC_GPIO_PORT1 , 0}, // SPI-MISO                           P1.0
     /* 13  */   {XMC_GPIO_PORT0 , 7}, // SPI-SCK / LED BUILTIN output       P0.7
     /* 14  */   {XMC_GPIO_PORT2 , 3}, // AREF                               P2.3 (INPUT ONLY)
-    /* 15  */   {XMC_GPIO_PORT2 , 1}, // I2C Data / Address SDA             P2.1
-    /* 16  */   {XMC_GPIO_PORT2 , 0}, // I2C Clock SCL                      P2.0
+    /* 15  */   {XMC_GPIO_PORT2 , 1}, // I2C Data / Address SDA / A7  ADC   P2.1
+    /* 16  */   {XMC_GPIO_PORT2 , 0}, // I2C Clock SCL / A6  ADC            P2.0
     /* 17  */   {XMC_GPIO_PORT2 , 6}, // A0 / ADC Input                     P2.6 (INPUT ONLY)
     /* 18  */   {XMC_GPIO_PORT2 , 8}, // A1 / ADC Input                     P2.8 (INPUT ONLY)
     /* 19  */   {XMC_GPIO_PORT2 , 9}, // A2 / ADC Input                     P2.9 (INPUT ONLY)
@@ -165,7 +166,9 @@ XMC_ADC_t mapping_adc[] =
     {VADC, 2, DISABLED},
     {VADC, 3, DISABLED},
     {VADC, 4, DISABLED},
-    {VADC, 7, DISABLED}
+    {VADC, 7, DISABLED},
+    {VADC, 5, DISABLED},
+    {VADC, 6, DISABLED}
 };
 
 /*

--- a/arm/variants/XMC1100/config/XMC1100_XMC2GO/pins_arduino.h
+++ b/arm/variants/XMC1100/config/XMC1100_XMC2GO/pins_arduino.h
@@ -92,8 +92,8 @@ const uint8_t mapping_pin_PWM4[][ 2 ] = {
 
 const XMC_PORT_PIN_t mapping_port_pin[] =
 {
-    /* 0  */    {XMC_GPIO_PORT0, 7},    // SPI-MOSI                         P0.7
-    /* 1  */    {XMC_GPIO_PORT0 , 6},   // SPI-MISO                         P0.6
+    /* 0  */    {XMC_GPIO_PORT0, 6},    // SPI-MOSI                         P0.6
+    /* 1  */    {XMC_GPIO_PORT0 , 7},   // SPI-MISO                         P0.7
     /* 2  */    {XMC_GPIO_PORT0 , 8},   // SPI-SCK                          P0.8
     /* 3  */    {XMC_GPIO_PORT0 , 9},   // SPI-SS                           P0.9
     /* 4  */    {XMC_GPIO_PORT0 , 14},  // GPIO                             P0.14
@@ -105,7 +105,7 @@ const XMC_PORT_PIN_t mapping_port_pin[] =
     /* 10  */   {XMC_GPIO_PORT2 , 11},  // I2C Clock SCL                    P2.11
     /* 11  */   {XMC_GPIO_PORT2 , 10},  // I2C Data / Address SDA           P2.10
     /* 12  */   {XMC_GPIO_PORT2 , 9},   // A0 / ADC Input                   P2.9 (INPUT ONLY)
-    /* 13  */   {XMC_GPIO_PORT2 , 7},   // A1                               P2.7 (INPUT ONLY)
+    /* 13  */   {XMC_GPIO_PORT2 , 7},   // A1 / ADC Input                   P2.7 (INPUT ONLY)
     /* 14  */   {XMC_GPIO_PORT1 , 1},   // LED 1 output    (BUILTIN)        P1.1
     /* 15  */   {XMC_GPIO_PORT1 , 0},   // LED 2 output                     P1.0
     /* 16  */   {XMC_GPIO_PORT2 , 1},   // DEBUG_TX                         P2.1

--- a/arm/variants/XMC1300/config/XMC1300_Boot_Kit/pins_arduino.h
+++ b/arm/variants/XMC1300/config/XMC1300_Boot_Kit/pins_arduino.h
@@ -40,7 +40,8 @@
 /* On board LED is ON when digital output is 0, LOW, False, OFF */
 #define  XMC_LED_ON         0
 
-#define NUM_ANALOG_INPUTS   6
+/* Modified to allow all possible analogue input pins */
+#define NUM_ANALOG_INPUTS   12
 #define NUM_PWM             4
 #define NUM_LEDS            6
 #define NUM_INTERRUPT       2
@@ -78,6 +79,12 @@
 #define A3   3
 #define A4   4
 #define A5   5
+#define A6   6
+#define A7   7
+#define A8   8
+#define A9   9
+#define A10  10
+#define A11  11
 
 #define PIN_SPI_SS_2  23
 
@@ -89,7 +96,7 @@
 #define AUX_4       29  // AUX
 #define AUX_5       30  // AUX
 
-#define LED_BUILTIN 24 	// Standard Arduino LED pin 13
+#define LED_BUILTIN 24 	// Standard Arduino LED
 #define LED1        24  // Extended LEDs P0.0
 #define LED2        25  // Extended LEDs P0.1
 #define LED3        29	// Extended LEDs P0.6
@@ -117,68 +124,75 @@ const uint8_t mapping_pin_PWM8[][ 2 ] = {
 
 const XMC_PORT_PIN_t mapping_port_pin[] =
 {
-	/* 0  */ 	{XMC_GPIO_PORT2 ,4},  // A0 / ADC Input 					P2.4 (INPUT ONLY)
-	/* 1  */ 	{XMC_GPIO_PORT2 ,5},  // A1 / ADC Input 					P2.5 (INPUT ONLY)
-	/* 2  */ 	{XMC_GPIO_PORT2 ,6},  // A2 / ADC Input						P2.6 (INPUT ONLY)
-	/* 3  */ 	{XMC_GPIO_PORT2 ,7},  // A3 / ADC Input						P2.7 (INPUT ONLY)
-	/* 4  */ 	{XMC_GPIO_PORT2 ,8},  // A4 / ADC Input						P2.8 (INPUT ONLY)
-	/* 5  */ 	{XMC_GPIO_PORT2 ,9},  // A5 / ADC Input						P2.9 (INPUT ONLY)
-	/* 6  */ 	{XMC_GPIO_PORT2 ,10}, // GPIO								P2.10
-	/* 7  */ 	{XMC_GPIO_PORT2 ,11}, // GPIO								P2.11
-	/* 8  */ 	{XMC_GPIO_PORT2 ,2},  // GPIO								P2.2 (INPUT ONLY)
-	/* 9  */ 	{XMC_GPIO_PORT2 ,3},  // GPIO								P2.3 (INPUT ONLY)
-	/* 10  */ 	{XMC_GPIO_PORT2 ,0},  // I2C Clock SCL						P2.0
-	/* 11  */ 	{XMC_GPIO_PORT2 ,1},  // I2C Data / Address SDA				P2.1
-	/* 12  */ 	{XMC_GPIO_PORT0 ,14}, // GPIO								P0.14
-	/* 13  */ 	{XMC_GPIO_PORT0 ,15}, // GPIO								P0.15
-	/* 14  */ 	{XMC_GPIO_PORT0 ,12}, // External interrupt	0				P0.12
-	/* 15  */ 	{XMC_GPIO_PORT0 ,13}, // External interrupt	1				P0.13
-	/* 16  */ 	{XMC_GPIO_PORT0 ,10}, // GPIO								P0.10
-	/* 17  */ 	{XMC_GPIO_PORT0 ,11}, // GPIO								P0.11
-	/* 18  */ 	{XMC_GPIO_PORT1 ,5},  // GPIO								P1.5
-	/* 19  */ 	{XMC_GPIO_PORT1 ,4},  // GPIO								P1.4
-	/* 20  */ 	{XMC_GPIO_PORT1 ,3},  // TX 	    			  			P1.3
-	/* 21  */ 	{XMC_GPIO_PORT1, 2},  // RX     	 						P1.2
-	/* 22  */ 	{XMC_GPIO_PORT1 ,1},  // SPI-MOSI							P1.1
-	/* 23  */ 	{XMC_GPIO_PORT1 ,0},  // SPI-MIS0							P1.0
-	/* 24  */ 	{XMC_GPIO_PORT0 ,0},  // LED output	LED1	(BUILTIN)		P0.0
-	/* 25  */ 	{XMC_GPIO_PORT0 ,1},  // LED output	LED2					P0.1
-	/* 26  */ 	{XMC_GPIO_PORT0 ,2},  // PWM (PWM4 slice 1)					P0.2
-	/* 27  */ 	{XMC_GPIO_PORT0 ,8},  // LED output		LED5				P0.8
-	/* 28  */ 	{XMC_GPIO_PORT0 ,9},  // LED output		LED6				P0.9
-	/* 29  */ 	{XMC_GPIO_PORT0 ,6},  // SPI-SS / LED output LED3			P0.6
-	/* 30  */ 	{XMC_GPIO_PORT0 ,7},  // SPI-SCK / LED output LED4			P0.7
-	/* 31  */ 	{XMC_GPIO_PORT0 ,4},  // PWM (PWM4 slice 0)					P0.4
-	/* 32  */ 	{XMC_GPIO_PORT0 ,5},  // PWM (PWM8 slice 0)					P0.5
-	/* 33  */ 	{XMC_GPIO_PORT0 ,3}   // PWM (PWM8 slice 1)				    P0.3
+	/* 0  */ 	{ XMC_GPIO_PORT2, 4 },  // A0 / ADC Input 					P2.4    (INPUT ONLY)
+	/* 1  */ 	{ XMC_GPIO_PORT2, 5 },  // A1 / ADC Input 					P2.5    (INPUT ONLY)
+	/* 2  */ 	{ XMC_GPIO_PORT2, 6 },  // A2 / ADC Input					P2.6    (INPUT ONLY)
+	/* 3  */ 	{ XMC_GPIO_PORT2, 7 },  // A3 / ADC Input					P2.7    (INPUT ONLY)
+	/* 4  */ 	{ XMC_GPIO_PORT2, 8 },  // A4 / ADC Input					P2.8    (INPUT ONLY)
+	/* 5  */ 	{ XMC_GPIO_PORT2, 9 },  // A5 / ADC Input					P2.9    (INPUT ONLY)
+	/* 6  */ 	{ XMC_GPIO_PORT2, 10 }, // GPIO / A6 ADC Input				P2.10
+	/* 7  */ 	{ XMC_GPIO_PORT2, 11 }, // GPIO / A7 ADC Input				P2.11
+	/* 8  */ 	{ XMC_GPIO_PORT2, 2 },  // GPIO / A9 ADC Input				P2.2    (INPUT ONLY)
+	/* 9  */ 	{ XMC_GPIO_PORT2, 3 },  // GPIO / A8 ADC Input				P2.3    (INPUT ONLY)
+	/* 10  */ 	{ XMC_GPIO_PORT2, 0 },  // I2C Clock SCL / A11 ADC Input	P2.0
+	/* 11  */ 	{ XMC_GPIO_PORT2, 1 },  // I2C Data  SDA / A10 ADC Input    P2.1
+	/* 12  */ 	{ XMC_GPIO_PORT0, 14 }, // GPIO								P0.14
+	/* 13  */ 	{ XMC_GPIO_PORT0, 15 }, // GPIO								P0.15
+	/* 14  */ 	{ XMC_GPIO_PORT0, 12 }, // External interrupt	0			P0.12
+	/* 15  */ 	{ XMC_GPIO_PORT0, 13 }, // External interrupt	1			P0.13
+	/* 16  */ 	{ XMC_GPIO_PORT0, 10 }, // GPIO								P0.10
+	/* 17  */ 	{ XMC_GPIO_PORT0, 11 }, // GPIO								P0.11
+	/* 18  */ 	{ XMC_GPIO_PORT1, 5 },  // GPIO								P1.5
+	/* 19  */ 	{ XMC_GPIO_PORT1, 4 },  // GPIO								P1.4
+	/* 20  */ 	{ XMC_GPIO_PORT1, 3 },  // TX 	    			  			P1.3
+	/* 21  */ 	{ XMC_GPIO_PORT1, 2 },  // RX     	 						P1.2
+	/* 22  */ 	{ XMC_GPIO_PORT1, 1 },  // SPI-MOSI							P1.1
+	/* 23  */ 	{ XMC_GPIO_PORT1, 0 },  // SPI-MIS0							P1.0
+	/* 24  */ 	{ XMC_GPIO_PORT0, 0 },  // LED output	(BUILTIN)   LED1	P0.0
+	/* 25  */ 	{ XMC_GPIO_PORT0, 1 },  // LED output	            LED2	P0.1
+	/* 26  */ 	{ XMC_GPIO_PORT0, 2 },  // PWM (PWM4 slice 1)				P0.2
+	/* 27  */ 	{ XMC_GPIO_PORT0, 8 },  // LED output	    	    LED5	P0.8
+	/* 28  */ 	{ XMC_GPIO_PORT0, 9 },  // LED output		        LED6	P0.9
+	/* 29  */ 	{ XMC_GPIO_PORT0, 6 },  // SPI-SS / LED output      LED3   	P0.6
+	/* 30  */ 	{ XMC_GPIO_PORT0, 7 },  // SPI-SCK / LED output     LED4	P0.7
+	/* 31  */ 	{ XMC_GPIO_PORT0, 4 },  // PWM (PWM4 slice 0)				P0.4
+	/* 32  */ 	{ XMC_GPIO_PORT0, 5 },  // PWM (PWM8 slice 0)				P0.5
+	/* 33  */ 	{ XMC_GPIO_PORT0, 3 }   // PWM (PWM8 slice 1)			    P0.3
 };
 
 const XMC_PIN_INTERRUPT_t mapping_interrupt[] =
 {
-    /* 0  */    {CCU40, CCU40_CC40, 0, 0, CCU40_IN0_P0_12},
-    /* 1  */    {CCU40, CCU40_CC40, 0, 1, CCU40_IN0_U0C0_DX2INS}
+    /* 0  */    { CCU40, CCU40_CC40, 0, 0, CCU40_IN0_P0_12 },
+    /* 1  */    { CCU40, CCU40_CC40, 0, 1, CCU40_IN0_U0C0_DX2INS }
 };
 
 XMC_PWM4_t mapping_pwm4[] =
 {
-    {CCU40, CCU40_CC41, 1, mapping_port_pin[31], P0_4_AF_CCU40_OUT1, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED}, // PWM disabled  31  P0.4
-    {CCU40, CCU40_CC42, 2, mapping_port_pin[26], P0_2_AF_CCU40_OUT2, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED}  // PWM disabled  26  P0.2
+    { CCU40, CCU40_CC41, 1, mapping_port_pin[ 31 ], P0_4_AF_CCU40_OUT1, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED }, // PWM disabled  31  P0.4
+    { CCU40, CCU40_CC42, 2, mapping_port_pin[ 26 ], P0_2_AF_CCU40_OUT2, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED }  // PWM disabled  26  P0.2
 };
 
 XMC_PWM8_t mapping_pwm8[] =
 {
-    {CCU80, CCU80_CC81, 1, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[32], P0_5_AF_CCU80_OUT12, XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD , DISABLED},  // PWM disabled  32   P0.5
-    {CCU80, CCU80_CC80, 0, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[33], P0_3_AF_CCU80_OUT03, XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD , DISABLED}   // PWM disabled  33   P0.3
+    { CCU80, CCU80_CC81, 1, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[ 32 ], P0_5_AF_CCU80_OUT12, XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED },  // PWM disabled  32   P0.5
+    { CCU80, CCU80_CC80, 0, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[ 33 ], P0_3_AF_CCU80_OUT03, XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED }   // PWM disabled  33   P0.3
 };
 
 XMC_ADC_t mapping_adc[] =
 {
-    {VADC, 6, VADC_G1, 1, 4 , DISABLED},
-    {VADC, 7, VADC_G1, 1, 11, DISABLED},
-    {VADC, 0, VADC_G0, 0, 9	, DISABLED},
-    {VADC, 1, VADC_G1, 1, 12, DISABLED},
-    {VADC, 1, VADC_G0, 0, 10, DISABLED},
-    {VADC, 2, VADC_G0, 0, 7 , DISABLED}
+    { VADC, 6, VADC_G1, 1, 4, DISABLED },
+    { VADC, 7, VADC_G1, 1, 11, DISABLED },
+    { VADC, 0, VADC_G0, 0, 9, DISABLED },
+    { VADC, 1, VADC_G1, 1, 12, DISABLED },
+    { VADC, 1, VADC_G0, 0, 10, DISABLED },
+    { VADC, 2, VADC_G0, 0, 7, DISABLED },
+    // Additional channels added here
+    { VADC, 3, VADC_G0, 0, 5, DISABLED },
+    { VADC, 4, VADC_G0, 0, 1, DISABLED },
+    { VADC, 5, VADC_G1, 1, 2, DISABLED },
+    { VADC, 7, VADC_G0, 0, 3, DISABLED },
+    { VADC, 6, VADC_G0, 0, 6, DISABLED },
+    { VADC, 5, VADC_G0, 0, 8, DISABLED }
 };
 
 /*


### PR DESCRIPTION
XMC2GO pin 0 and pin 1 were swapped compared to other documentation

Analog functions for init and read improved

PWM prescaler bug in CCU8 gave wrong prescaler

Add more safety, code reduction and documentation