### PR TITLE
analogRead

### DIFF
--- a/arm/cores/wiring_analog.c
+++ b/arm/cores/wiring_analog.c
@@ -111,12 +111,28 @@ void analogReference( uint8_t ulMode )
 analog_reference = ulMode;
 }
 
-// analogRead takes parameter of ADC channel number
+// analogRead takes parameter of ADC channel number or the pin
 // return 0 for invalid channel
 // Would prefer a return of 0xFFFFFFFF to be obvious in code/debug when wrong
 // instead of valid value as it has been done
-uint32_t analogRead( uint8_t channel )
+uint32_t analogRead( uint8_t pin )
 {
+//in case the given argument is a pin it gets translated to a channel number
+uint8_t channel = pin >= A0 ? pin - A0 : pin;
+	
+//XMC4700 is by now the only XMC Board which has more than 6 analog pins.
+//Therefore also if(NUM_ANALOG_INPUTS > 6) would work here, but it might be incompatible with future boards
+#if defined(XMC4700_Relax_Kit)
+if( pin >= A14 )
+{
+	channel = pin - A14 + 14;
+}
+else if( pin >= A6 )
+{
+	channel = pin - A6 + 6;
+}
+#endif
+	
 uint32_t value = 0;
 
 if( channel < NUM_ANALOG_INPUTS )

--- a/arm/cores/wiring_analog.c
+++ b/arm/cores/wiring_analog.c
@@ -120,14 +120,18 @@ uint32_t analogRead( uint8_t pin )
 //in case the given argument is a pin it gets translated to a channel number
 uint8_t channel = pin >= A0 ? pin - A0 : pin;
 	
-//XMC4700 is by now the only XMC Board which has more than 6 analog pins.
-//Therefore also if(NUM_ANALOG_INPUTS > 6) would work here, but it might be incompatible with future boards
-#if defined(XMC4700_Relax_Kit)
+//If there are more than the standard 6 pins
+#if defined(A14)
 if( pin >= A14 )
 {
 	channel = pin - A14 + 14;
 }
 else if( pin >= A6 )
+{
+	channel = pin - A6 + 6;
+}
+#elif defined(A6)
+if( pin >= A6 )
 {
 	channel = pin - A6 + 6;
 }

--- a/arm/variants/XMC1100/config/XMC1100_Boot_Kit/pins_arduino.h
+++ b/arm/variants/XMC1100/config/XMC1100_Boot_Kit/pins_arduino.h
@@ -74,12 +74,12 @@ extern uint8_t MOSI;
 extern uint8_t MISO;
 extern uint8_t SCK;
 
-#define A0   0
-#define A1   1
-#define A2   2
-#define A3   3
-#define A4   4
-#define A5   5
+#define A0   17
+#define A1   18
+#define A2   19
+#define A3   20
+#define A4   21
+#define A5   22
 
 #define AD_AUX_1    24  // AD_AUX
 #define AD_AUX_2    25  // AD_AUX

--- a/arm/variants/XMC1300/config/XMC1300_Boot_Kit/pins_arduino.h
+++ b/arm/variants/XMC1300/config/XMC1300_Boot_Kit/pins_arduino.h
@@ -77,12 +77,12 @@ extern uint8_t MOSI;
 extern uint8_t MISO;
 extern uint8_t SCK;
 
-#define A0   0
-#define A1   1
-#define A2   2
-#define A3   3
-#define A4   4
-#define A5   5
+#define A0   17
+#define A1   18
+#define A2   19
+#define A3   20
+#define A4   21
+#define A5   22
 
 #define PIN_SPI_SS_2  23
 

--- a/arm/variants/XMC1300/config/XMC1300_Sense2GoL/pins_arduino.h
+++ b/arm/variants/XMC1300/config/XMC1300_Sense2GoL/pins_arduino.h
@@ -68,8 +68,9 @@ extern uint8_t SCK;
 
 #define PIN_AREF      14
 
-#define A0   0
-#define A1   1
+//Might be wrong as mapping_port_pin[] seems to be incorrect
+#define A0   17
+#define A1   18
 
 // These 2 lines should be defined in higher level or examples
 #define CH_I A0

--- a/arm/variants/XMC1400/config/XMC1400_Boot_Kit/pins_arduino.h
+++ b/arm/variants/XMC1400/config/XMC1400_Boot_Kit/pins_arduino.h
@@ -59,12 +59,12 @@
 #define PIN_SPI_MISO  12
 #define PIN_SPI_SCK   13
 
-#define A0   0
-#define A1   1
-#define A2   2
-#define A3   3
-#define A4   4
-#define A5   5
+#define A0   17
+#define A1   18
+#define A2   19
+#define A3   20
+#define A4   21
+#define A5   22
 
 #define LED_BUILTIN LED1  
 #define LED1        24  

--- a/arm/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
+++ b/arm/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
@@ -79,29 +79,29 @@ static const uint8_t MOSI_SD = PIN_SPI_MOSI_SD;
 static const uint8_t MISO_SD = PIN_SPI_MISO_SD;
 static const uint8_t SCK_SD  = PIN_SPI_SCK_SD;
 
-#define A0   0
-#define A1   1
-#define A2   2
-#define A3   3
-#define A4   4
-#define A5   5
+#define A0   17
+#define A1   18
+#define A2   19
+#define A3   20
+#define A4   21
+#define A5   22
 //Additional ADC ports starting here
-#define A6	 6		// ADC G2CH6 on P15.6
-#define A7	 7		// ADC G2CH5 on P15.5
-#define A8	 8		// ADC G2CH3 on P15.3
-#define A9	 9		// ADC G1CH7 on P14.15
-#define A10	 10		// ADC G1CH5 on P14.13
-#define A11	 11		// ADC G0CH7 on P14.7
-#define A12	 12		// ADC G3CH7 on P15.15
-#define A13	 13		// ADC G1CH1 on P14.9
-#define A14	 14		// ADC G1CH0 on P14.8
-#define A15	 15		// ADC G3CH6 on P15.14
-#define A16	 16		// ADC G0CH6 on P14.6
-#define A17	 17		// ADC G1CH4 on P14.12
-#define A18	 18		// ADC G1CH6 on P14.14
-#define A19	 19		// ADC G2CH2 on P15.2
-#define A20	 20		// ADC G2CH4 on P15.4
-#define A21	 21		// ADC G2CH7 on P15.7
+#define A6	 43		// ADC G2CH6 on P15.6
+#define A7	 44		// ADC G2CH5 on P15.5
+#define A8	 45		// ADC G2CH3 on P15.3
+#define A9	 46		// ADC G1CH7 on P14.15
+#define A10	 47		// ADC G1CH5 on P14.13
+#define A11	 48		// ADC G0CH7 on P14.7
+#define A12	 49		// ADC G3CH7 on P15.15
+#define A13	 50		// ADC G1CH1 on P14.9
+#define A14	 55		// ADC G1CH0 on P14.8
+#define A15	 56		// ADC G3CH6 on P15.14
+#define A16	 57		// ADC G0CH6 on P14.6
+#define A17	 58		// ADC G1CH4 on P14.12
+#define A18	 59		// ADC G1CH6 on P14.14
+#define A19	 60		// ADC G2CH2 on P15.2
+#define A20	 61		// ADC G2CH4 on P15.4
+#define A21	 62		// ADC G2CH7 on P15.7
 // ADC G3CH0 on P15.8	not available
 // ADC G3CH1 on P15.9	not available
 // ADC G3CH4 on P15.12	button

--- a/arm/variants/XMC4800/config/XMC4800_Relax_Kit/pins_arduino.h
+++ b/arm/variants/XMC4800/config/XMC4800_Relax_Kit/pins_arduino.h
@@ -75,12 +75,12 @@ static const uint8_t MOSI_SD = PIN_SPI_MOSI_SD;
 static const uint8_t MISO_SD = PIN_SPI_MISO_SD;
 static const uint8_t SCK_SD  = PIN_SPI_SCK_SD;
 
-#define A0   0
-#define A1   1
-#define A2   2
-#define A3   3
-#define A4   4
-#define A5   5
+#define A0   17
+#define A1   18
+#define A2   19
+#define A3   20
+#define A4   21
+#define A5   22
 
 #define LED_BUILTIN	13	// Standard Arduino LED
 #define LED1	    24	// Additional LED1


### PR DESCRIPTION
Changed analogRead() so that it accepts both: channel numbers and pin numbers.
Also the defines of the analog pins in pins_arduino.h are changed to match their pin numbers in mapping_port_pin[].
Advantages of this change are that digitalRead(A0) works now properly (previously it deliverd the pin state of digital pin D0).
Also there is a difference now between analog and digital pins, which can be used by software to check whether a pin is analog or digital (e.g. if pin number is out of the range of digital pins, it has to be a analog pin).
And the change improves the compatibility to original Arduino, where it's implemented similar.