### PR TITLE
Fixes to H-Bridge2Go Implementation

### DIFF
--- a/arm/libraries/IFX9201/examples/MotorControl/MotorControl.ino
+++ b/arm/libraries/IFX9201/examples/MotorControl/MotorControl.ino
@@ -19,8 +19,8 @@ void setup() {
   IFX9201_HBridge.begin(SPI, CSN, DIR, PWM, DIS);
 
   // Use PWM Mode
-  // Change the CSN, DIR, PWM, and DIS pins to custom ones for other boards
-  // IFX9201_HBridge.begin(CSN, DIR, PWM, DIS);
+  // Change the DIR, PWM, and DIS pins to custom ones for other boards
+  // IFX9201_HBridge.begin(DIR, PWM, DIS);
   
   delay(1000);        
 }

--- a/arm/libraries/IFX9201/src/IFX9201.cpp
+++ b/arm/libraries/IFX9201/src/IFX9201.cpp
@@ -142,7 +142,7 @@ uint8_t IFX9201::forwards(uint8_t duty_cycle)
 	{
 		digitalWrite(m_Direction, HIGH);
 		analogWrite(m_PWM, DutyCycleToanlogWriteValue(duty_cycle));
-		digitalWrite(m_Disable, HIGH);
+		digitalWrite(m_Disable, LOW);
 	}
 	return ret;
 }
@@ -158,7 +158,7 @@ uint8_t IFX9201::backwards(uint8_t duty_cycle)
 	{
 		digitalWrite(m_Direction, LOW);
 		analogWrite(m_PWM, DutyCycleToanlogWriteValue(duty_cycle));
-		digitalWrite(m_Disable, HIGH);
+		digitalWrite(m_Disable, LOW);
 	}
 	return ret;
 }
@@ -174,7 +174,7 @@ uint8_t IFX9201::stop(void)
 	{
 		digitalWrite(m_Direction, LOW);
 		analogWrite(m_PWM, 0u);
-		digitalWrite(m_Disable, LOW);
+		digitalWrite(m_Disable, HIGH);
 	}
 	return ret;
 }

--- a/arm/variants/XMC1100/config/XMC1100_H_BRIDGE2GO/pins_arduino.h
+++ b/arm/variants/XMC1100/config/XMC1100_H_BRIDGE2GO/pins_arduino.h
@@ -92,8 +92,8 @@ extern uint8_t SCK;
 //#define SCK 	PIN_SPI_SCK
 #define CSN 	PIN_SPI_SS
 #define DIR		6
-#define PWM 	10
-#define DIS		11
+#define DIS		10
+#define PWM 	11
 
 #define digitalPinToInterrupt(p)    (((p) == 9) ? 0 : NOT_AN_INTERRUPT)
 
@@ -103,7 +103,8 @@ extern uint8_t SCK;
    Putting both parts in array means if a PWM4 channel gets reassigned for
    another function later a gap in channel numbers will not mess things up */
    const uint8_t mapping_pin_PWM4[][ 2 ] = {
-    { 8, 10 },
+    { 8, 0 },
+    { 11, 1},
     { 255, 255 } };
 
 const XMC_PORT_PIN_t mapping_port_pin[] =
@@ -118,8 +119,8 @@ const XMC_PORT_PIN_t mapping_port_pin[] =
     /* 7  */    {XMC_GPIO_PORT2 , 6},   // GPIO		                        P2.6 (INPUT ONLY)
     /* 8  */    {XMC_GPIO_PORT0 , 5},   // PWM0 output                      P0.5
     /* 9  */    {XMC_GPIO_PORT0 , 0},   // External interrupt               P0.0
-    /* 10  */   {XMC_GPIO_PORT2 , 11},  // PWM / PWM1 output (Fixed on PCB) P2.11
-    /* 11  */   {XMC_GPIO_PORT2 , 10},  // DIS  (Fixed on PCB)              P2.10
+    /* 10  */   {XMC_GPIO_PORT2 , 11},  // DIS  (Fixed on PCB)              P2.11
+    /* 11  */   {XMC_GPIO_PORT2 , 10},  // PWM / PWM1 output (Fixed on PCB) P2.10
     /* 12  */   {XMC_GPIO_PORT2 , 9},   // A0 / ADC Input                   P2.9 (INPUT ONLY)
     /* 13  */   {XMC_GPIO_PORT2 , 7},   // A1 / ADC Input                   P2.7 (INPUT ONLY)
     /* 14  */   {XMC_GPIO_PORT1 , 1},   // LED1 output                      P1.1

--- a/arm/variants/XMC1100/config/XMC1100_H_BRIDGE2GO/pins_arduino.h
+++ b/arm/variants/XMC1100/config/XMC1100_H_BRIDGE2GO/pins_arduino.h
@@ -137,7 +137,7 @@ const XMC_PIN_INTERRUPT_t mapping_interrupt[] =
 XMC_PWM4_t mapping_pwm4[] =
 {
     {CCU40, CCU40_CC40, 0, mapping_port_pin[8],  P0_0_AF_CCU40_OUT0,  XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED}, // PWM disabled  8    P0.5
-    {CCU40, CCU40_CC43, 3, mapping_port_pin[10], P2_11_AF_CCU40_OUT3, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED}  // PWM disabled  10   P2.11
+    {CCU40, CCU40_CC42, 2, mapping_port_pin[11], P2_10_AF_CCU40_OUT2, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED}  // PWM disabled  10   P2.11
 };
 
 XMC_ADC_t mapping_adc[] =


### PR DESCRIPTION
Pins of PWM and DIS were swapped (also wrong labels on PCB):
PWM is on P2.10 = Arduino Pin 11
DIS is on P2.11 = Arduino Pin 10

Fixes to mapping_pin_PWM4:
- Pin 8 was mapped to non-existing index 10 -> changed to index 0
- Added entry for Pin 11 (PWM of H-Bridge) -> mapped to index 1