### PR TITLE
xmc2go: Swap MISO and MOSI pins

### DIFF
--- a/arm/variants/XMC1100/config/XMC1100_XMC2GO/pins_arduino.h
+++ b/arm/variants/XMC1100/config/XMC1100_XMC2GO/pins_arduino.h
@@ -67,8 +67,8 @@
 #define PCLK 64000000u 
  
 #define PIN_SPI_SS    3
-#define PIN_SPI_MOSI  0
-#define PIN_SPI_MISO  1
+#define PIN_SPI_MOSI  1
+#define PIN_SPI_MISO  0
 #define PIN_SPI_SCK   2
 
 extern uint8_t SS; 
@@ -102,8 +102,8 @@ const uint8_t mapping_pin_PWM4[][ 2 ] = {
 
 const XMC_PORT_PIN_t mapping_port_pin[] =
 {
-    /* 0  */    {XMC_GPIO_PORT0 , 6},   // SPI-MOSI                         P0.6
-    /* 1  */    {XMC_GPIO_PORT0 , 7},   // SPI-MISO / PWM40-1 output        P0.7
+    /* 0  */    {XMC_GPIO_PORT0 , 6},   // SPI-MISO                         P0.6
+    /* 1  */    {XMC_GPIO_PORT0 , 7},   // SPI-MOSI / PWM40-1 output        P0.7
     /* 2  */    {XMC_GPIO_PORT0 , 8},   // SPI-SCK / PWM40-2 output         P0.8
     /* 3  */    {XMC_GPIO_PORT0 , 9},   // SPI-SS  / PWM40-3 output         P0.9
     /* 4  */    {XMC_GPIO_PORT0 , 14},  // GPIO                             P0.14


### PR DESCRIPTION
This commit swaps MISO and MOSI to keep compatibility with Shield2Go
layout.

While pin 0 and pin 1 were swapped previously (https://github.com/Infineon/XMC-for-Arduino/commit/0cacb835822d0b32779c1e7a74961a93d55e09d3),
MISO and MOSI pins were never swapped to keep compatibility with
existing hardware.

This commit follows XMC H-Bridge 2Go pin layout file: https://github.com/Infineon/XMC-for-Arduino/blob/37be6555e8c69921ff91253ec965c73cbc399535/arm/variants/XMC1100/config/XMC1100_H_BRIDGE2GO/pins_arduino.h#L72

Correct layout example: https://www.infineon.com/export/sites/default/_images/product/evaluation-boards/DPS310-Pressure-Shield2Go_Top_web.png_2070606871.png