### PR TITLE
XMC4X00: Silence compiler warning by exposing correct arch

### DIFF
--- a/arm/variants/XMC4700/startup_XMC4700.S
+++ b/arm/variants/XMC4700/startup_XMC4700.S
@@ -1,8 +1,8 @@
 /*********************************************************************************************************************
  * @file     startup_XMC4700.S
  * @brief    CMSIS Core Device Startup File for Infineon XMC4700 Device Series
- * @version  V1.1
- * @date     05 Jan 2016
+ * @version  V1.2
+ * @date     24 Jan 2020
  *
  * @cond
  *********************************************************************************************************************
@@ -36,9 +36,17 @@
  **************************** Change history ********************************
  * V1.0,Sep, 03, 2015 JFT:Initial version
  * V1.1,Jan, 05, 2016 JFT:Fix .reset section attributes
+ * V1.2,Jan, 24, 2020, Silence compiler warning
  *
  * @endcond 
  */
+
+/* Silence "IT blocks containing more than one conditional instruction
+ * are deprecated in ARMv8" warning.
+ *
+ * XMC4700 is a Cortex-M4, which has an ARMv7E-M architecture.
+ */
+.arch  armv7e-m
 
 /* ===========START : MACRO DEFINITION MACRO DEFINITION ================== */
  

--- a/arm/variants/XMC4800/startup_XMC4800.S
+++ b/arm/variants/XMC4800/startup_XMC4800.S
@@ -1,8 +1,8 @@
 /*********************************************************************************************************************
  * @file     startup_XMC4800.S
  * @brief    CMSIS Core Device Startup File for Infineon XMC4800 Device Series
- * @version  V1.1
- * @date     05 Jan 2016
+ * @version  V1.2
+ * @date     24 Jan 2020
  *
  * @cond
  *********************************************************************************************************************
@@ -36,9 +36,17 @@
  **************************** Change history ********************************
  * V1.0,Sep, 03, 2015 JFT:Initial version
  * V1.1,Jan, 05, 2016 JFT:Fix .reset section attributes
+ * V1.2,Jan, 24, 2020, Silence compiler warning
  *
  * @endcond 
  */
+
+/* Silence "IT blocks containing more than one conditional instruction
+ * are deprecated in ARMv8" warning.
+ *
+ * XMC4800 is a Cortex-M4, which has an ARMv7E-M architecture.
+ */
+.arch  armv7e-m
 
 /* ===========START : MACRO DEFINITION MACRO DEFINITION ================== */
  


### PR DESCRIPTION
Both xmc4700 and xmc4800 are Cortex-M4 based microcontrollers, as
so, both have ARMv7E-M instruction sets.

This commit silences the following warning:
"IT blocks containing more than one conditional instruction are
deprecated in ARMv8"

As my xmc4700 relax kit didn't arrive yet, I wasn't able to test it on real hardware.
I would be really grateful if someone tested it before merge.
Also, I was in doubt if the file version should be changed. Is it okay like that?