### PR TITLE
Fix simple Bugs in Radar XMC4700

### DIFF
--- a/arm/boards.txt
+++ b/arm/boards.txt
@@ -234,7 +234,10 @@ XMC4700_Radar_Baseboard.build.variant=XMC4700
 XMC4700_Radar_Baseboard.build.board_variant=XMC4700_Radar_Baseboard
 XMC4700_Radar_Baseboard.build.flash_size=2000K
 XMC4700_Radar_Baseboard.build.flash_ld=linker_script.ld
-XMC4700_Radar_Baseboard.build.extra_flags=-DARM_MATH_CM4 -DARM_MATH_DSP -DUSB0 -DINTERRUPT_USE_ERU -DSERIAL_USE_U1C1
+# Old version causes redefinition errors
+#XMC4700_Radar_Baseboard.build.extra_flags=-DARM_MATH_CM4 -DARM_MATH_DSP -DUSB0 -DINTERRUPT_USE_ERU -DSERIAL_USE_U1C1
+# New Version Jan-2020 PC
+XMC4700_Radar_Baseboard.build.extra_flags=-DARM_MATH_CM4 -DINTERRUPT_USE_ERU -DSERIAL_USE_U1C1
 
 ####################################################
 XMC4700_Relax_Kit.name=XMC4700 Relax Kit

--- a/arm/variants/XMC4700/config/XMC4700_Radar_Baseboard/pins_arduino.h
+++ b/arm/variants/XMC4700/config/XMC4700_Radar_Baseboard/pins_arduino.h
@@ -40,9 +40,9 @@
 #define XMC_BOARD           DEMO Radar BB XMC4700
 /* On board LED is ON when digital output is 0, LOW, False, OFF */
 #define XMC_LED_ON          0
-
-#define NUM_ANALOG_INPUTS   6 // Pins that are allocated or free to be used as Analog input
-#define NUM_PWM             5
+// Pins that are allocated or free to be used as Analog input
+#define NUM_ANALOG_INPUTS   6 
+#define NUM_PWM             6
 #define NUM_LEDS            0
 #define NUM_INTERRUPT       2
 #define NUM_SERIAL          1
@@ -118,7 +118,7 @@ const XMC_PORT_PIN_t mapping_port_pin[] =
     /* 0  */    {XMC_GPIO_PORT3, 14},   // RX                           P3.14 (also DEBUG_RX)
     /* 1  */    {XMC_GPIO_PORT3, 15},   // TX                           P3.15 (also DEBUG_TX)
     /* 2  */    {XMC_GPIO_PORT0, 4},    // GPIO / External INT 2        P0.4
-	/* 3  */    {XMC_GPIO_PORT4, 6},    // PWM43-0 output / Ext INT 1   P4.6
+    /* 3  */    {XMC_GPIO_PORT4, 6},    // PWM43-0 output / Ext INT 1   P4.6
     /* 4  */    {XMC_GPIO_PORT2, 7},    // GPIO                         P2.7
     /* 5  */    {XMC_GPIO_PORT7, 6},    // PWM42-2 output               P7.6
     /* 6  */    {XMC_GPIO_PORT3, 10},   // PWM41-0 output               P3.10
@@ -147,8 +147,7 @@ const XMC_PORT_PIN_t mapping_port_pin[] =
     /* 29 */    {XMC_GPIO_PORT3, 6},    // SPI-SCK  (SD CARD)           P3.6
     /* 30  */   {XMC_GPIO_PORT1, 6},    // SD DATA 1                    P1.6
     /* 31  */   {XMC_GPIO_PORT1, 7},    // SD DATA 2                    P1.7
-
-	/* 32 */    {XMC_GPIO_PORT0, 3},    //  External INT 1 (Alt Pin 3)  P0.3
+    /* 32 */    {XMC_GPIO_PORT0, 3},    //  External INT 1 (Alt Pin 3)  P0.3
     /* 33 */    {XMC_GPIO_PORT0, 6},    //  PWM8 input2 (Alt Pin 5)     P0.6
     /* 34 */    {XMC_GPIO_PORT5, 0},    //  PWM8 input1 (Alt Pin 6)     P5.0
     /* 35 */    {XMC_GPIO_PORT9, 7},    //  SPI-CS3 (Alt Pin 7)         P9.7


### PR DESCRIPTION
##  pins_arduino.h
Commenting bug on NUM_ANALOG_INPUTS
NUM_PWM did not match list of PWMs assigned

## boards.txt 
Wrong compiler flags that was resolved September 2019 for similar XMC4700 Relax kit
causes redefinition of constants in other modules

Other potential bug exists in
~~~
    const XMC_PIN_INTERRUPT_t mapping_interrupt[] =
~~~
Where this board has 6 entries per row ALL other boards use 5 per row

No time at present to chase this down, I suggest original author @mohamemu  check this