### PR TITLE
Config: Set correct PCLK values

### DIFF
--- a/arm/variants/XMC1400/config/XMC1400_Boot_Kit/pins_arduino.h
+++ b/arm/variants/XMC1400/config/XMC1400_Boot_Kit/pins_arduino.h
@@ -52,7 +52,7 @@
 
 #define PWM4_TIMER_PERIOD (2041U)  // Generate 490Hz @fCCU=1MHz
 
-#define PCLK 48000000u 
+#define PCLK 96000000u 
  
 #define PIN_SPI_SS    10
 #define PIN_SPI_MOSI  11

--- a/arm/variants/XMC4700/config/XMC4700_Radar_Baseboard/pins_arduino.h
+++ b/arm/variants/XMC4700/config/XMC4700_Radar_Baseboard/pins_arduino.h
@@ -56,7 +56,7 @@
 #define PWM4_TIMER_PERIOD (0x11EF)  // Generate 490Hz @fCCU=144MHz
 #define PWM8_TIMER_PERIOD (0x11EF)  // Generate 490Hz @fCCU=144MHz
 
-#define PCLK 64000000u 
+#define PCLK 144000000u 
  
 #define PIN_SPI_SS    10
 #define PIN_SPI_MOSI  11

--- a/arm/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
+++ b/arm/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
@@ -56,7 +56,7 @@
 #define PWM4_TIMER_PERIOD (0x11EF)  // Generate 490Hz @fCCU=144MHz
 #define PWM8_TIMER_PERIOD (0x11EF)  // Generate 490Hz @fCCU=144MHz
 
-#define PCLK 64000000u 
+#define PCLK 144000000u 
  
 #define PIN_SPI_SS    10
 #define PIN_SPI_MOSI  11

--- a/arm/variants/XMC4800/config/XMC4800_Relax_Kit/pins_arduino.h
+++ b/arm/variants/XMC4800/config/XMC4800_Relax_Kit/pins_arduino.h
@@ -53,7 +53,7 @@ Boston, MA  02111-1307  USA
 #define PWM4_TIMER_PERIOD (0x11EF)  // Generate 490Hz @fCCU=144MHz
 #define PWM8_TIMER_PERIOD (0x11EF)  // Generate 490Hz @fCCU=144MHz
 
-#define PCLK 64000000u 
+#define PCLK 144000000u 
  
 #define PIN_SPI_SS    10
 #define PIN_SPI_MOSI  11


### PR DESCRIPTION
These boards had their PCLK set to a wrong value, causing the function
"setAnalogWriteFrequency" to misbehave.
An example can be seen in the image below, where a frequency of 50hz was set
on a XMC4700 Relax board:
 - Previous: https://i.imgur.com/9vfwv1d.jpg
 - After: https://i.imgur.com/YGaZxsM.jpg

PCLK values were taken from the datasheets of each MCU. For XMC1400, the PCLK
also matches the one set by its initialization/startup rotine.