### PR TITLE
Updating XMC4400 Wire Protocol Interrupt number form 91 to 92

### DIFF
--- a/libraries/Wire/src/utility/xmc_i2c_conf.c
+++ b/libraries/Wire/src/utility/xmc_i2c_conf.c
@@ -226,7 +226,7 @@ XMC_I2C_t XMC_I2C_0 =
     .input_source_dx1 = XMC_INPUT_B,
     .slave_receive_irq_num                    = (IRQn_Type) 91,
     .slave_receive_irq_service_request        = 1 ,
-    .protocol_irq_num                   	  = (IRQn_Type) 91,
+    .protocol_irq_num                   	  = (IRQn_Type) 92,
     .protocol_irq_service_request       	  = 2
 };
 


### PR DESCRIPTION
Protocol IRQ number in Line 229 inside xmc_i2c_conf.c was 91 in place of 92.