### PR TITLE
Fix typo specifying wrong input source for XMC1100 BootKit USIC

### DIFF
--- a/variants/XMC1100/config/XMC1100_Boot_Kit/pins_arduino.h
+++ b/variants/XMC1100/config/XMC1100_Boot_Kit/pins_arduino.h
@@ -211,7 +211,7 @@ XMC_UART_t XMC_UART_0 =
 #ifdef SERIAL_DEBUG
   .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C1_DX0_P1_3,
 #else
-  .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C0_DX0_P1_2,
+  .input_source_dx0     = (XMC_USIC_INPUT_t)USIC0_C1_DX0_P1_2,
 #endif
   .input_source_dx1     = XMC_INPUT_INVALID,
   .input_source_dx2     = XMC_INPUT_INVALID,


### PR DESCRIPTION
 - when compiling with -DSERIAL_ONBOARD the define SERIAL_DEBUG becomes undefined.
   This leads to the use of P1_2 as inputsource of USIC0_CH1. The corresponding define
   specifies USIC0_C0_DX0_P1_2 which does not exist for XMC1100. Therefore
   the define has been changed to the correct CH1 define USIC0_C1_DX0_P1_2.