### PR TITLE
Fix for issue 199 for version 1.x

### DIFF
--- a/variants/XMC4400/config/XMC4400_Platform2GO/pins_arduino.h
+++ b/variants/XMC4400/config/XMC4400_Platform2GO/pins_arduino.h
@@ -96,12 +96,12 @@ extern uint8_t SCK;
 #define A16  16
 #define A17  17
 
-#define LED1        65
-#define LED2        62
+#define LED1        66
+#define LED2        63
 #define LED_BUILTIN LED1
 
-#define BUTTON1     68
-#define BUTTON2     57
+#define BUTTON1     69
+#define BUTTON2     58
 
 #define digitalPinToInterrupt(p)    ((p) == 2 ? 0 : ((p) == 3 ? 1 : NOT_AN_INTERRUPT))
 
@@ -144,9 +144,9 @@ const XMC_PORT_PIN_t mapping_port_pin[]=
     //Additional pins for port X1 starting here
     /* 25 */  {XMC_GPIO_PORT2, 10}, // GPIO / ETH_LED                         P2.10                          X1-37
     /* 26 */  {XMC_GPIO_PORT2, 8},  // GPIO / ETH_TXDO / PWM80-32             P2.8                           X1-35                
-    /* 27 */  {XMC_GPIO_PORT2, 4},  // GPIO / ETH_RXER                        P2.4                           X1-33
+    /* 27 */  {XMC_GPIO_PORT2, 4},  // GPIO / ETH_RXER / PWM41-1              P2.4                           X1-33
     /* 28 */  {XMC_GPIO_PORT2, 3},  // ETH_RXD1 / PWM41-2                     P2.3                           X1-32
-    /* 29 */  {XMC_GPIO_PORT2, 2},  // GPIO / ETH_RXDO                        P2.2                           X1-31
+    /* 29 */  {XMC_GPIO_PORT2, 2},  // GPIO / ETH_RXDO / PWM41-3              P2.2                           X1-31
     /* 30 */  {XMC_GPIO_PORT2, 0},  // GPIO / ETH_MDIO / PWM81-21             P2.0                           X1-29
     /* 31 */  {XMC_GPIO_PORT2, 6},  // PWM80-13 / GPIO4_2GO_2                 P2.6                           X1-27
     /* 32 */  {XMC_GPIO_PORT5, 2},  // GPIO / RST                             P5.2                           X1-25
@@ -214,8 +214,8 @@ const uint8_t mapping_pin_PWM4[][ 2 ] = {
                                         { 5, 1 },   // PWM1
                                         { 6, 2 },   // PWM2
                                         { 27, 3 },  // PWM
-                                        { 28, 4 },  // PWM
-                                        { 14, 5 },  // PWM
+                                        { 29, 4 },  // PWM
+                                        { 28, 5 },  // PWM
                                         { 15, 6 },  // PWM
                                         { 255, 255 } };
 
@@ -227,8 +227,8 @@ XMC_PWM4_t mapping_pwm4[] =
     {CCU42, CCU42_CC42, 2, mapping_port_pin[6], P3_4_AF_CCU42_OUT2,  XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED}, // PWM disabled  6  P3.4
 
     {CCU41, CCU41_CC41, 1, mapping_port_pin[27], P2_4_AF_CCU41_OUT1, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED}, // PWM disabled  27   P2.4
-    {CCU41, CCU41_CC43, 3, mapping_port_pin[28], P2_2_AF_CCU41_OUT3, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED}, // PWM disabled  28   P2.2
-    {CCU41, CCU41_CC42, 2, mapping_port_pin[14], P2_3_AF_CCU41_OUT2, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED}, // PWM disabled  14   P2.3
+    {CCU41, CCU41_CC43, 3, mapping_port_pin[29], P2_2_AF_CCU41_OUT3, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED}, // PWM disabled  29   P2.2
+    {CCU41, CCU41_CC42, 2, mapping_port_pin[28], P2_3_AF_CCU41_OUT2, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED}, // PWM disabled  28   P2.3
     {CCU41, CCU41_CC40, 0, mapping_port_pin[15], P2_5_AF_CCU41_OUT0, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED}, // PWM disabled  15   P2.5
     };
 const uint8_t NUM_PWM4 = ( sizeof( mapping_pwm4 ) / sizeof( XMC_PWM4_t ) );
@@ -238,12 +238,12 @@ const uint8_t mapping_pin_PWM8[][ 2 ] = {
                                         { 9,  0 },  // PWM3
                                         { 10, 1 },  // PWM4
                                         { 26, 2 },  // PWM
-                                        { 29, 3 },  // PWM
-                                        { 30, 4 },  // PWM
-                                        { 45, 5 },  // PWM
-                                        { 46, 6 },  // PWM
-                                        { 48, 7 },  // PWM
-                                        { 67, 8 },  // PWM
+                                        { 30, 3 },  // PWM
+                                        { 31, 4 },  // PWM
+                                        { 46, 5 },  // PWM
+                                        { 47, 6 },  // PWM
+                                        { 49, 7 },  // PWM
+                                        { 68, 8 },  // PWM
                                         { 255, 255 } };
 
 /* Configurations of PWM channels for CCU8 type */
@@ -253,12 +253,12 @@ XMC_PWM8_t mapping_pwm8[] =
     {CCU80, CCU80_CC80, 0, XMC_CCU8_SLICE_COMPARE_CHANNEL_1, mapping_port_pin[10],  P0_2_AF_CCU80_OUT01, XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED}, // PWM disabled  10 P0.2
     //additional pwm outputs starting here
     {CCU80, CCU80_CC83, 3, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[26], P2_8_AF_CCU80_OUT32,  XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED}, // PWM disabled  26 P2.8
-    {CCU81, CCU81_CC82, 2, XMC_CCU8_SLICE_COMPARE_CHANNEL_1, mapping_port_pin[29], P2_0_AF_CCU81_OUT21,  XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED}, // PWM disabled  29 P2.0
-    {CCU80, CCU80_CC81, 1, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[30], P2_6_AF_CCU80_OUT13,  XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED}, // PWM disabled  30 P2.6
-    {CCU81, CCU81_CC80, 0, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[45], P5_7_AF_CCU81_OUT02,  XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED}, // PWM disabled  45 P5.7
-    {CCU80, CCU80_CC80, 0, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[46], P2_7_AF_CCU80_OUT03,  XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED}, // PWM disabled  46 P2.7
-    {CCU80, CCU80_CC82, 2, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[48], P2_9_AF_CCU80_OUT22,  XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED}, // PWM disabled  48 P2.9
-    {CCU80, CCU80_CC81, 1, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[67], P0_9_AF_CCU80_OUT12,  XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED}  // PWM disabled  67 P0.9    
+    {CCU81, CCU81_CC82, 2, XMC_CCU8_SLICE_COMPARE_CHANNEL_1, mapping_port_pin[30], P2_0_AF_CCU81_OUT21,  XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED}, // PWM disabled  30 P2.0
+    {CCU80, CCU80_CC81, 1, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[31], P2_6_AF_CCU80_OUT13,  XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED}, // PWM disabled  31 P2.6
+    {CCU81, CCU81_CC80, 0, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[46], P5_7_AF_CCU81_OUT02,  XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED}, // PWM disabled  46 P5.7
+    {CCU80, CCU80_CC80, 0, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[47], P2_7_AF_CCU80_OUT03,  XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED}, // PWM disabled  47 P2.7
+    {CCU80, CCU80_CC82, 2, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[49], P2_9_AF_CCU80_OUT22,  XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED}, // PWM disabled  49 P2.9
+    {CCU80, CCU80_CC81, 1, XMC_CCU8_SLICE_COMPARE_CHANNEL_2, mapping_port_pin[68], P0_9_AF_CCU80_OUT12,  XMC_CCU8_SLICE_PRESCALER_64, PWM8_TIMER_PERIOD, DISABLED}  // PWM disabled  68 P0.9    
     };
 
 const uint8_t NUM_PWM8 = ( sizeof( mapping_pwm8 ) / sizeof( XMC_PWM8_t ) );
@@ -268,8 +268,8 @@ const uint8_t NUM_PWM  = ( sizeof( mapping_pwm4 ) / sizeof( XMC_PWM4_t ) )
 /* Analog Pin mappings and configurations */
 #ifdef DAC
 const uint8_t mapping_pin_DAC[][ 2 ] = {
-                                        { 50, 0 },
-                                        { 72, 1 },
+                                        { 51, 0 },
+                                        { 73, 1 },
                                         { 255, 255 } };
 
 /* Analog Pin mappings and configurations */

--- a/variants/XMC4400/config/XMC4400_Platform2GO/pins_arduino.h
+++ b/variants/XMC4400/config/XMC4400_Platform2GO/pins_arduino.h
@@ -107,6 +107,12 @@ extern uint8_t SCK;
 
 #ifdef ARDUINO_MAIN
 // Mapping of digital pins and comments
+/***
+IMPORTANT NOTE
+    Entry at Arduino pin 14 is a PLACEHOLDER
+    Invalid pin assignment, but removing would lead to breaking legacy code, due to change
+    of other pin assignments.
+***/
 const XMC_PORT_PIN_t mapping_port_pin[]=
     {
     /* 0  */  {XMC_GPIO_PORT2, 15}, // RX                                     P2.15                          X1-4              
@@ -123,7 +129,7 @@ const XMC_PORT_PIN_t mapping_port_pin[]=
     /* 11 */  {XMC_GPIO_PORT1, 9},  // SPI-MOSI                               P1.9                           X1-10
     /* 12 */  {XMC_GPIO_PORT0, 0},  // SPI-MISO                               P0.0                           X2-18
     /* 13 */  {XMC_GPIO_PORT1, 8},  // SPI-SCK / GPIO                         P1.8                           X1-9
-    /* 14 */  {XMC_GPIO_PORT2, 3},  // AREF TODO: / ETH_RXD1 / PWM41-2        P2.3                           X1-32
+    /* 14 */  {XMC_GPIO_PORT15, 2}, // --- Note: DUMMY pin assignment, to prevent incompatibility of legacy code! ---
     /* 15 */  {XMC_GPIO_PORT2, 5},  // I2C Data / Address SDA / A4 / PWM41-0  P2.5  (Hardwired to A4)        X1-34
     /* 16 */  {XMC_GPIO_PORT3, 0},  // I2C Clock SCL  / A5 - ADC Input        P3.0  (Hardwired to A5)        X2-19
     /* 17 */  {XMC_GPIO_PORT14, 0}, // A0 / ADC Input                         P14.0 (INPUT ONLY)               
@@ -139,53 +145,54 @@ const XMC_PORT_PIN_t mapping_port_pin[]=
     /* 25 */  {XMC_GPIO_PORT2, 10}, // GPIO / ETH_LED                         P2.10                          X1-37
     /* 26 */  {XMC_GPIO_PORT2, 8},  // GPIO / ETH_TXDO / PWM80-32             P2.8                           X1-35                
     /* 27 */  {XMC_GPIO_PORT2, 4},  // GPIO / ETH_RXER                        P2.4                           X1-33
-    /* 28 */  {XMC_GPIO_PORT2, 2},  // GPIO / ETH_RXDO                        P2.2                           X1-31
-    /* 29 */  {XMC_GPIO_PORT2, 0},  // GPIO / ETH_MDIO / PWM81-21             P2.0                           X1-29
-    /* 30 */  {XMC_GPIO_PORT2, 6},  // PWM80-13 / GPIO4_2GO_2                 P2.6                           X1-27  
-    /* 31 */  {XMC_GPIO_PORT5, 2},  // GPIO / RST                             P5.2                           X1-25
-    /* 32 */  {XMC_GPIO_PORT5, 0},  // GPIO1_2GO_1                            P5.0                           X1-23  
-    /* 33 */  {XMC_GPIO_PORT1, 12}, // GPIO / CAN_TX                          P1.12                          X1-19
-    /* 34 */  {XMC_GPIO_PORT1, 10}, // GPIO / GPIO2_2GO_1                     P1.10                          X1-17
-    /* 35 */  {XMC_GPIO_PORT1, 4},  // GPIO / QSPI_IO1                        P1.4                           X1-15  
-    /* 36 */  {XMC_GPIO_PORT1, 2},  // GPIO / QSPI_IO3                        P1.2                           X1-13    
-    /* 37 */  {XMC_GPIO_PORT4, 0},  // GPIO / GPIO2_2GO_2                     P4.0                           X1-5
-    /* 38 */  {XMC_GPIO_PORT1, 7},  // GPIO / SPI_CS_2GO_2                    P1.7 (Chip Select - Slot 2)    X1-8
-    /* 39 */  {XMC_GPIO_PORT1, 1},  // GPIO1_2GO_2                            P1.1                           X1-12
-    /* 40 */  {XMC_GPIO_PORT1, 3},  // GPIO / QSPI_IO3                        P1.3                           X1-14
-    /* 41 */  {XMC_GPIO_PORT1, 5},  // GPIO / QSPI_IO0                        P1.5                           X1-16          
-    /* 42 */  {XMC_GPIO_PORT1, 11}, // GPIO / QSPI_CS                         P1.11                          X1-18
-    /* 43 */  {XMC_GPIO_PORT1, 13}, // GPIO / CAN_RX                          P1.13                          X1-20
-    /* 44 */  {XMC_GPIO_PORT5, 1},  // GPIO / ETH_INT                         P5.1                           X1-24
-    /* 45 */  {XMC_GPIO_PORT5, 7},  // PWM81-02                               P5.7                           X1-26
-    /* 46 */  {XMC_GPIO_PORT2, 7},  // PWM80-03 / ETH_MDC                     P2.7                           X1-28
-    /* 47 */  {XMC_GPIO_PORT2, 1},  // SWV   ""DEBUG Do NOT Use **            P2.1                           X1-30
-    /* 48 */  {XMC_GPIO_PORT2, 9},  // PWM80-22 / ETH_TXD1                    P2.9                           X1-36  
-    /* 49 */  {XMC_GPIO_PORT15, 8}, // A16 / ETH_CLK                          P15.8                          X1-38
+    /* 28 */  {XMC_GPIO_PORT2, 3},  // ETH_RXD1 / PWM41-2                     P2.3                           X1-32
+    /* 29 */  {XMC_GPIO_PORT2, 2},  // GPIO / ETH_RXDO                        P2.2                           X1-31
+    /* 30 */  {XMC_GPIO_PORT2, 0},  // GPIO / ETH_MDIO / PWM81-21             P2.0                           X1-29
+    /* 31 */  {XMC_GPIO_PORT2, 6},  // PWM80-13 / GPIO4_2GO_2                 P2.6                           X1-27
+    /* 32 */  {XMC_GPIO_PORT5, 2},  // GPIO / RST                             P5.2                           X1-25
+    /* 33 */  {XMC_GPIO_PORT5, 0},  // GPIO1_2GO_1                            P5.0                           X1-23
+    /* 34 */  {XMC_GPIO_PORT1, 12}, // GPIO / CAN_TX                          P1.12                          X1-19
+    /* 35 */  {XMC_GPIO_PORT1, 10}, // GPIO / GPIO2_2GO_1                     P1.10                          X1-17
+    /* 36 */  {XMC_GPIO_PORT1, 4},  // GPIO / QSPI_IO1                        P1.4                           X1-15
+    /* 37 */  {XMC_GPIO_PORT1, 2},  // GPIO / QSPI_IO3                        P1.2                           X1-13
+    /* 38 */  {XMC_GPIO_PORT4, 0},  // GPIO / GPIO2_2GO_2                     P4.0                           X1-5
+    /* 39 */  {XMC_GPIO_PORT1, 7},  // GPIO / SPI_CS_2GO_2                    P1.7 (Chip Select - Slot 2)    X1-8
+    /* 40 */  {XMC_GPIO_PORT1, 1},  // GPIO1_2GO_2                            P1.1                           X1-12
+    /* 41 */  {XMC_GPIO_PORT1, 3},  // GPIO / QSPI_IO3                        P1.3                           X1-14
+    /* 42 */  {XMC_GPIO_PORT1, 5},  // GPIO / QSPI_IO0                        P1.5                           X1-16
+    /* 43 */  {XMC_GPIO_PORT1, 11}, // GPIO / QSPI_CS                         P1.11                          X1-18
+    /* 44 */  {XMC_GPIO_PORT1, 13}, // GPIO / CAN_RX                          P1.13                          X1-20
+    /* 45 */  {XMC_GPIO_PORT5, 1},  // GPIO / ETH_INT                         P5.1                           X1-24
+    /* 46 */  {XMC_GPIO_PORT5, 7},  // PWM81-02                               P5.7                           X1-26
+    /* 47 */  {XMC_GPIO_PORT2, 7},  // PWM80-03 / ETH_MDC                     P2.7                           X1-28
+    /* 48 */  {XMC_GPIO_PORT2, 1},  // SWV   ""DEBUG Do NOT Use **            P2.1                           X1-30
+    /* 49 */  {XMC_GPIO_PORT2, 9},  // PWM80-22 / ETH_TXD1                    P2.9                           X1-36
+    /* 50 */  {XMC_GPIO_PORT15, 8}, // A16 / ETH_CLK                          P15.8                          X1-38
 
     //Additional pins for port X2 starting here
-    /* 50 */  {XMC_GPIO_PORT14, 8},  // A14 / DAC 0 Output                    P14.8                          X2-33
-    /* 51 */  {XMC_GPIO_PORT15, 2},  // A12 - ADC Input                       P15.2 (INPUT ONLY)             X2-32
-    /* 52 */  {XMC_GPIO_PORT14, 15}, // A11 - ADC Input                       P14.15 (INPUT ONLY)            X2-29
-    /* 53 */  {XMC_GPIO_PORT15, 9},  // A17 - ADC Input / ETH_CRS             P15.9                          X2-27
-    /* 54 */  {XMC_GPIO_PORT14, 6},  // A6 / AN1_2GO_1 - ADC Input            P14.6 (INPUT ONLY)             X2-25
-    /* 55 */  {XMC_GPIO_PORT14, 12}, // A8 / AN1_2GO_2 - ADC Input            P14.12 (INPUT ONLY)            X2-23
-    /* 56 */  {XMC_GPIO_PORT14, 14}, // A10 / ADC Input                       P14.14 (INPUT ONLY)            X2-21  
-    /* 57 */  {XMC_GPIO_PORT3, 2},   // BUTTON2                               P3.2                           X2-17    
-    /* 58 */  {XMC_GPIO_PORT0, 10},  // INT / GPIO3_2GO_1                     P0.10                          X2-15
-    /* 59 */  {XMC_GPIO_PORT0, 1},   // INT                                   P0.1                           X2-13
-    /* 60 */  {XMC_GPIO_PORT0, 3},   // INT / GPIO3_2GO_2                     P0.3                           X2-11      
-    /* 61 */  {XMC_GPIO_PORT3, 5},   // CS_2GO_1                              P3.5 (Chip Select - Slot 1)    X2-3
-    /* 62 */  {XMC_GPIO_PORT0, 7},   // LED2                                  P0.7                           X2-1  
-    /* 63 */  {XMC_GPIO_PORT0, 8},   // QSPI_CLK                              P0.8                           X2-4
-    /* 64 */  {XMC_GPIO_PORT0, 12},  // CS_MB                                 P0.12 (Chip Select - MikroBUS) X2-10
-    /* 65 */  {XMC_GPIO_PORT0, 6},   // LED1                                  P0.6                           X2-12
-    /* 66 */  {XMC_GPIO_PORT0, 4},   // ETH_TXEN                              P0.4                           X2-14
-    /* 67 */  {XMC_GPIO_PORT0, 9},   // GPIO4_2GO_1 / PWM80-12 / PWM          P0.9                           X2-20
-    /* 68 */  {XMC_GPIO_PORT3, 1},   // BUTTON1                               P3.1                           X2-22
-    /* 69 */  {XMC_GPIO_PORT14, 13}, // A9 / AN2_2GO_2 - ADC Input            P14.13 (INPUT ONLY)            X2-26
-    /* 70 */  {XMC_GPIO_PORT14, 7},  // A7 / AN2_2GO_1 - ADC Input            P14.7 (INPUT ONLY)             X2-28
-    /* 71 */  {XMC_GPIO_PORT15, 3},  // A13 - ADC Input                       P15.3 (INPUT ONLY)             X2-34
-    /* 72 */  {XMC_GPIO_PORT14, 9}   // A15 / DAC 1 Output                    P14.9                          X2-36
+    /* 51 */  {XMC_GPIO_PORT14, 8},  // A14 / DAC 0 Output                    P14.8                          X2-33
+    /* 52 */  {XMC_GPIO_PORT15, 2},  // A12 - ADC Input                       P15.2 (INPUT ONLY)             X2-32
+    /* 53 */  {XMC_GPIO_PORT14, 15}, // A11 - ADC Input                       P14.15 (INPUT ONLY)            X2-29
+    /* 54 */  {XMC_GPIO_PORT15, 9},  // A17 - ADC Input / ETH_CRS             P15.9                          X2-27
+    /* 55 */  {XMC_GPIO_PORT14, 6},  // A6 / AN1_2GO_1 - ADC Input            P14.6 (INPUT ONLY)             X2-25
+    /* 56 */  {XMC_GPIO_PORT14, 12}, // A8 / AN1_2GO_2 - ADC Input            P14.12 (INPUT ONLY)            X2-23
+    /* 57 */  {XMC_GPIO_PORT14, 14}, // A10 / ADC Input                       P14.14 (INPUT ONLY)            X2-21
+    /* 58 */  {XMC_GPIO_PORT3, 2},   // BUTTON2                               P3.2                           X2-17
+    /* 59 */  {XMC_GPIO_PORT0, 10},  // INT / GPIO3_2GO_1                     P0.10                          X2-15
+    /* 60 */  {XMC_GPIO_PORT0, 1},   // INT                                   P0.1                           X2-13
+    /* 61 */  {XMC_GPIO_PORT0, 3},   // INT / GPIO3_2GO_2                     P0.3                           X2-11
+    /* 62 */  {XMC_GPIO_PORT3, 5},   // CS_2GO_1                              P3.5 (Chip Select - Slot 1)    X2-3
+    /* 63 */  {XMC_GPIO_PORT0, 7},   // LED2                                  P0.7                           X2-1
+    /* 64 */  {XMC_GPIO_PORT0, 8},   // QSPI_CLK                              P0.8                           X2-4
+    /* 65 */  {XMC_GPIO_PORT0, 12},  // CS_MB                                 P0.12 (Chip Select - MikroBUS) X2-10
+    /* 66 */  {XMC_GPIO_PORT0, 6},   // LED1                                  P0.6                           X2-12
+    /* 67 */  {XMC_GPIO_PORT0, 4},   // ETH_TXEN                              P0.4                           X2-14
+    /* 68 */  {XMC_GPIO_PORT0, 9},   // GPIO4_2GO_1 / PWM80-12 / PWM          P0.9                           X2-20
+    /* 69 */  {XMC_GPIO_PORT3, 1},   // BUTTON1                               P3.1                           X2-22
+    /* 70 */  {XMC_GPIO_PORT14, 13}, // A9 / AN2_2GO_2 - ADC Input            P14.13 (INPUT ONLY)            X2-26
+    /* 71 */  {XMC_GPIO_PORT14, 7},  // A7 / AN2_2GO_1 - ADC Input            P14.7 (INPUT ONLY)             X2-28
+    /* 72 */  {XMC_GPIO_PORT15, 3},  // A13 - ADC Input                       P15.3 (INPUT ONLY)             X2-34
+    /* 73 */  {XMC_GPIO_PORT14, 9}   // A15 / DAC 1 Output                    P14.9                          X2-36
     };
 const uint8_t GND = ( sizeof( mapping_port_pin ) / sizeof( XMC_PORT_PIN_t ) );
 const uint8_t NUM_DIGITAL = ( sizeof( mapping_port_pin ) / sizeof( XMC_PORT_PIN_t ) );;

--- a/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
+++ b/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
@@ -133,9 +133,9 @@ static const uint8_t SCK_SD  = PIN_SPI_SCK_SD;
 // Mapping of digital pins and comments
 /***
 IMPORTANT NOTE
-    Extra entry at Arduino pin 23 is PLACEHOLDER
-    Duplicate wrong entry, but removing would mean changing many other
-    documents and reducing many pins for defines by 1
+    Extra entries at Arduino pin 23 & 14 are PLACEHOLDERS
+    Invalid pin assignments, but removing would mean changing many other
+    documents and pins defines -> might break legacy code.
 ***/
 const XMC_PORT_PIN_t mapping_port_pin[] =
     {
@@ -153,7 +153,7 @@ const XMC_PORT_PIN_t mapping_port_pin[] =
     /* 11  */   {XMC_GPIO_PORT3, 8},   // SPI-MOSI / PWM41-2 / PWM5    P3.8
     /* 12  */   {XMC_GPIO_PORT3, 7},   // SPI-MISO                     P3.7
     /* 13  */   {XMC_GPIO_PORT3, 9},   // SPI-SCK                      P3.9
-    /* 14  */   {XMC_GPIO_PORT2, 3},   // AREF TODO:                   P2.3
+    /* 14  */   {XMC_GPIO_PORT2, 3},   // --- Note: DUMMY pin assignment, to prevent incompatibility of legacy code! INVALID ---
     /* 15  */   {XMC_GPIO_PORT3, 15},  // I2C Data / Address SDA / A4  P3.15 (Hardwired to A4)
     /* 16  */   {XMC_GPIO_PORT0, 13},  // I2C Clock SCL / A5           P0.13 (Hardwired to A5)
     /* 17  */   {XMC_GPIO_PORT14, 0},  // A0 / ADC Input               P14.0 (INPUT ONLY)


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Pin 14 on XMC4 series boards is a VAREF pin and hence cannot be used as a GPIO.

Related Issue
Issue #199 

Context
In order to prevent old legacy code from breaking, the pin assignments have been kept the same by use of dummy assignments (floating pins on MCU). This is planned to be finally fixed in the upcoming version 2.x