### PR TITLE
added PWM to pins 10 and 11 of XMC1400 Arduino Kit as per user manual

### DIFF
--- a/variants/XMC1400/config/XMC1400_Arduino_Kit/pins_arduino.h
+++ b/variants/XMC1400/config/XMC1400_Arduino_Kit/pins_arduino.h
@@ -146,8 +146,8 @@ const XMC_PORT_PIN_t mapping_port_pin[] =
     /* 7  */    {XMC_GPIO_PORT0 , 13}, // GPIO                                    P0.13
     /* 8  */    {XMC_GPIO_PORT0 , 12}, // GPIO                                    P0.12
     /* 9  */    {XMC_GPIO_PORT0 , 7}, // PWM40-1 output                           P0.7
-    /* 10  */   {XMC_GPIO_PORT0 , 4}, // SPI-SS                                   P0.4
-    /* 11  */   {XMC_GPIO_PORT0 , 1}, // SPI-MOSI                                 P0.1
+    /* 10  */   {XMC_GPIO_PORT0 , 4}, // SPI-SS / PWM40-1                         P0.4
+    /* 11  */   {XMC_GPIO_PORT0 , 1}, // SPI-MOSI / PWM40-1                       P0.1
     /* 12  */   {XMC_GPIO_PORT0 , 0}, // SPI-MISO                                 P0.0
     /* 13  */   {XMC_GPIO_PORT0 , 3}, // SPI-SCK                                  P0.3
     /* 14  */   {XMC_GPIO_PORT2 , 3}, // AREF * DO NOT USE as GPIO or REF **      P2.3 (INPUT ONLY)
@@ -186,6 +186,8 @@ const uint8_t mapping_pin_PWM4[][ 2 ] = {
                                         { 4, 1 },
                                         { 6, 2 },
                                         { 9, 3 },
+                                        { 10, 4},
+                                        { 11, 5},
                                         { 255, 255 } };
 
 /* Configurations of PWM channels for CCU4 type */
@@ -194,7 +196,9 @@ XMC_PWM4_t mapping_pwm4[] =
     {CCU40, CCU40_CC41, 1, mapping_port_pin[3], P1_1_AF_CCU40_OUT1, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED},  // PWM disabled  4
     {CCU40, CCU40_CC40, 0, mapping_port_pin[4], P1_0_AF_CCU40_OUT0, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED},  // PWM disabled  4
     {CCU41, CCU41_CC40, 0, mapping_port_pin[6], P0_6_AF_CCU41_OUT0, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED},  // PWM disabled  4
-    {CCU40, CCU40_CC41, 1, mapping_port_pin[9], P0_7_AF_CCU40_OUT1, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED}  // PWM disabled  4
+    {CCU40, CCU40_CC41, 1, mapping_port_pin[9], P0_7_AF_CCU40_OUT1, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED},  // PWM disabled  4
+    {CCU40, CCU40_CC41, 1, mapping_port_pin[10], P0_4_AF_CCU40_OUT1, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED},  // PWM disabled  4
+    {CCU40, CCU40_CC41, 1, mapping_port_pin[11], P0_1_AF_CCU40_OUT1, XMC_CCU4_SLICE_PRESCALER_64, PWM4_TIMER_PERIOD, DISABLED}  // PWM disabled  4
     };
 
 const uint8_t NUM_PWM4  = ( sizeof( mapping_pwm4 ) / sizeof( XMC_PWM4_t ) );


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Enable PWM on pins 10 and 11 of XMC1400 Kit for Arduino 

Context
To make the BSP compatible with the User Manual, PWM must be enabled on pins 10 and 11, as shown below.  

![image](https://user-images.githubusercontent.com/105282041/196060386-050c5c3c-c375-4a5a-b8a7-7fc17b228bbb.png)
