### PR TITLE
updated I2C & SPI config with radar base board

### DIFF
--- a/libraries/BGT24LTR11-Pulsed-Doppler-Radar/README.md
+++ b/libraries/BGT24LTR11-Pulsed-Doppler-Radar/README.md
@@ -216,6 +216,12 @@ The pre-defined fast speed threshold can be changed within the Arduino sketch.
 
 ![Predefined Threshold](https://raw.githubusercontent.com/infineon/assets/master/Pictures/rbb_Predefined_Threshold.png)
 
+## Known Issues
+
+### Warnings after Compilation
+
+There could be warnings appearing even after the successful compilation of examples. They are due to the static library of USB and from the external Andee.h library. 
+
 ## Additional Information
 See also our [Wiki](https://github.com/Infineon/XMC-for-Arduino/wiki/Core-Libraries) and doxygen-generated [documentation page](https://github.com/Infineon/InfineonDoxyGenerator).
 

--- a/libraries/BGT24LTR11-Pulsed-Doppler-Radar/examples/RadarPulsedDoppler_Andee_RGB/RadarPulsedDoppler_Andee_RGB.ino
+++ b/libraries/BGT24LTR11-Pulsed-Doppler-Radar/examples/RadarPulsedDoppler_Andee_RGB/RadarPulsedDoppler_Andee_RGB.ino
@@ -4,6 +4,7 @@
 // Always include these libraries. Annikken Andee needs them
 // to work with the Arduino!
 #include <SPI.h>
+//Download Andee Library from Library manager
 #include <Andee.h>
 
 // Pre-defined threshold for "fast" speed 

--- a/libraries/SPI/src/utility/xmc_spi_conf.c
+++ b/libraries/SPI/src/utility/xmc_spi_conf.c
@@ -223,7 +223,7 @@ XMC_SPI_t XMC_SPI_0 =
     },
 };
 
-#elif defined(XMC4700_Relax_Kit)
+#elif defined(XMC4700_Relax_Kit) || defined(XMC4700_Radar_Baseboard)
 XMC_SPI_t XMC_SPI_0 =
 {
     .channel          = XMC_SPI2_CH0,

--- a/libraries/SPI/src/utility/xmc_spi_conf.h
+++ b/libraries/SPI/src/utility/xmc_spi_conf.h
@@ -72,7 +72,7 @@ extern XMC_SPI_t XMC_SPI_0;
 #define NUM_SPI  			1
 extern XMC_SPI_t XMC_SPI_0;
 
-#elif defined(XMC4700_Relax_Kit)
+#elif defined(XMC4700_Relax_Kit) || defined(XMC4700_Radar_Baseboard)
 #define NUM_SPI  			3
 #define XMC_SPI_for_xmc_SD	XMC_SPI_1
 extern XMC_SPI_t XMC_SPI_0;

--- a/libraries/Wire/src/utility/xmc_i2c_conf.c
+++ b/libraries/Wire/src/utility/xmc_i2c_conf.c
@@ -30,7 +30,7 @@
 #include "xmc_i2c_conf.h"
 
 #if defined(XMC1100_XMC2GO)
-XMC_I2C_t XMC_I2C_0 =
+XMC_I2C_t  =
 {
     .channel          = XMC_I2C0_CH1,
     .channel_config   = {
@@ -297,7 +297,7 @@ XMC_I2C_t XMC_I2C_0 =
 };
 
 
-#elif defined(XMC4700_Relax_Kit)
+#elif defined(XMC4700_Relax_Kit) ||defined(XMC4700_Radar_Baseboard)
 XMC_I2C_t XMC_I2C_0 =
 {
     .channel          = XMC_I2C1_CH1,

--- a/libraries/Wire/src/utility/xmc_i2c_conf.h
+++ b/libraries/Wire/src/utility/xmc_i2c_conf.h
@@ -76,7 +76,7 @@ extern XMC_I2C_t XMC_I2C_0;
 #define NUM_I2C  1
 extern XMC_I2C_t XMC_I2C_0;
 
-#elif defined(XMC4700_Relax_Kit)
+#elif defined(XMC4700_Relax_Kit) || defined(XMC4700_Radar_Baseboard)
 #define NUM_I2C  2
 extern XMC_I2C_t XMC_I2C_0;
 extern XMC_I2C_t XMC_I2C_1;


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
XMC4700 Radar baseboard was missing in the SPI & I2C config files. Due to this in the example, Radar_pulsed_Doppler_Andee_RGB was showing errors. It's fixed by this pull request.

Related Issue
If you opened an issue before creating the PR, point to it here.

Context
What do we need to know about your development environment, tools, target, and so on. Screenshots are always helpful if there is a UI element to this PR.