### PR TITLE
Support for XMC2GO 32K Flash

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -91,6 +91,50 @@ XMC1100_XMC2GO.menu.LIB.DSPNN=ARM DSP / ARM NN Framework
 XMC1100_XMC2GO.menu.LIB.DSPNN.library.selected=-DARM_LIB_CMSIS_DSP -DARM_LIB_CMSIS_NN
 
 ####################################################
+XMC1100_XMC2GO_32K.name=XMC1100 XMC2Go (32K Flash)
+XMC1100_XMC2GO_32K.upload.tool=xmcprog
+XMC1100_XMC2GO_32K.upload.speed=115200
+XMC1100_XMC2GO_32K.upload.resetmethod=ck
+XMC1100_XMC2GO_32K.upload.maximum_size=32768
+XMC1100_XMC2GO_32K.upload.wait_for_upload_port=true
+
+XMC1100_XMC2GO_32K.communication=usb
+XMC1100_XMC2GO_32K.protocol=dragon_isp
+XMC1100_XMC2GO_32K.program.protocol=dragon_isp
+XMC1100_XMC2GO_32K.program.tool=xmcprog
+XMC1100_XMC2GO_32K.program.extra_params=-Pusb
+
+XMC1100_XMC2GO_32K.serial.disableDTR=true
+XMC1100_XMC2GO_32K.serial.disableRTS=true
+
+XMC1100_XMC2GO_32K.build.mcu=cortex-m0
+XMC1100_XMC2GO_32K.build.f_cpu=32000000L
+XMC1100_XMC2GO_32K.build.board=ARM_XMC
+XMC1100_XMC2GO_32K.build.board.version=1100
+XMC1100_XMC2GO_32K.build.board.type=T038x0032
+XMC1100_XMC2GO_32K.build.board.v=0032
+XMC1100_XMC2GO_32K.build.core=./
+XMC1100_XMC2GO_32K.build.variant=XMC1100
+XMC1100_XMC2GO_32K.build.board_variant=XMC1100_XMC2GO
+XMC1100_XMC2GO_32K.build.flash_size=32K
+XMC1100_XMC2GO_32K.build.flash_ld=linker_script.ld
+XMC1100_XMC2GO_32K.build.extra_flags=-DARM_MATH_CM0 -DXMC1_SERIES
+
+XMC1100_XMC2GO_32K.menu.UART.debug=PC
+XMC1100_XMC2GO_32K.menu.UART.debug.uart.selected=-DSERIAL_HOSTPC
+XMC1100_XMC2GO_32K.menu.UART.onBoard=On Board
+XMC1100_XMC2GO_32K.menu.UART.onBoard.uart.selected=-DSERIAL_ONBOARD
+
+XMC1100_XMC2GO_32K.menu.LIB.NONE=None
+XMC1100_XMC2GO_32K.menu.LIB.NONE.library.selected=
+XMC1100_XMC2GO_32K.menu.LIB.NN=ARM NN Framework
+XMC1100_XMC2GO_32K.menu.LIB.NN.library.selected=-DARM_LIB_CMSIS_NN
+XMC1100_XMC2GO_32K.menu.LIB.DSP=ARM DSP
+XMC1100_XMC2GO_32K.menu.LIB.DSP.library.selected=-DARM_LIB_CMSIS_DSP
+XMC1100_XMC2GO_32K.menu.LIB.DSPNN=ARM DSP / ARM NN Framework
+XMC1100_XMC2GO_32K.menu.LIB.DSPNN.library.selected=-DARM_LIB_CMSIS_DSP -DARM_LIB_CMSIS_NN
+
+####################################################
 XMC1300_Boot_Kit.name=XMC1300 Boot Kit
 XMC1300_Boot_Kit.upload.tool=xmcprog
 XMC1300_Boot_Kit.upload.speed=115200


### PR DESCRIPTION
Hi! Thank you for for this project and the arduino support! xmc2go works great.
I would like to mention that these boards are available with 32K or 64K flash.
Unfortunately you cannot explicitly order the 64K version! (Supplier confirmed that)
With Chip 032B instead of 064B you get an error when uploading >32k.
I have now 10 pieces and it is the 32K version only :(
(Other people i know received the 64K version)