### PR TITLE
Changes to boards.txt for V1.7

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -67,7 +67,7 @@ XMC1100_XMC2GO.build.mcu=cortex-m0
 XMC1100_XMC2GO.build.f_cpu=32000000L
 XMC1100_XMC2GO.build.board=ARM_XMC
 XMC1100_XMC2GO.build.board.version=1100
-XMC1100_XMC2GO.build.board.type=T038x0064
+XMC1100_XMC2GO.build.board.type=Q024x0064
 XMC1100_XMC2GO.build.board.v=0064
 XMC1100_XMC2GO.build.core=./
 XMC1100_XMC2GO.build.variant=XMC1100
@@ -111,7 +111,7 @@ XMC1100_H_BRIDGE2GO.build.mcu=cortex-m0
 XMC1100_H_BRIDGE2GO.build.f_cpu=32000000L
 XMC1100_H_BRIDGE2GO.build.board=ARM_XMC
 XMC1100_H_BRIDGE2GO.build.board.version=1100
-XMC1100_H_BRIDGE2GO.build.board.type=T038x0064
+XMC1100_H_BRIDGE2GO.build.board.type=Q024x0064
 XMC1100_H_BRIDGE2GO.build.board.v=0064
 XMC1100_H_BRIDGE2GO.build.core=./
 XMC1100_H_BRIDGE2GO.build.variant=XMC1100
@@ -121,7 +121,7 @@ XMC1100_H_BRIDGE2GO.build.flash_ld=linker_script.ld
 XMC1100_H_BRIDGE2GO.build.extra_flags=-DARM_MATH_CM0 -DXMC1_SERIES
 
 XMC1100_H_BRIDGE2GO.menu.UART.debug=PC
-XMC1100_H_BRIDGE2GO.menu.UART.debug.uart.selected=-DSERIAL_ONBOARD
+XMC1100_H_BRIDGE2GO.menu.UART.debug.uart.selected=-DSERIAL_HOSTPC
 XMC1100_H_BRIDGE2GO.menu.UART.onBoard=On Board
 XMC1100_H_BRIDGE2GO.menu.UART.onBoard.uart.selected=-DSERIAL_ONBOARD
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Certain mistakes in boards.txt

Context

- Information in boards.txt file is verified.
- Mistakes found and corrected, similar to V2.x
- Serial communication via PC was not working before on HBRIDGE2Go due to a wrong compile-time define. Corrected

Testing

- No testing required for the changes similar to V2.x since the change was only in the package number of the XMC1100 in XMC2Go is changed. This would only change the define macros for the particular device type. There are no differences in those except for the pins that do not occur in one package. Hence, there is no need of explicit testing.
- For the change related to HBRIDGE2Go, serial communication can be checked with a serial client on PC, using an example sketch.