### PR TITLE
V2.x LED Library reversed LED_BUILTIN

### DIFF
--- a/libraries/LED/Readme.md
+++ b/libraries/LED/Readme.md
@@ -5,8 +5,8 @@
 **Author** | : | Paul Carpenter
  | | | PC Services
  | | | www.pcserviceselectronics.co.uk
-**Version** | : | V1.0.3
-**Updated** | : | August 2022
+**Version** | : | V1.0.4
+**Updated** | : | March 2023
 Date | : | July 2018
 
 Infineon XMC-for-Arduino LED Library, to assist in making board agnostic examples that
@@ -42,18 +42,20 @@ models of board so we end up with
  XMC1100 XMC2GO | High | No | High
  XMC1100 XMC H Bridge2GO | High| No | High
  XMC1300 Boot Kit  | Low | No | Low
- XMC1300 Sense2GOL | Low| No | Low
+ XMC1300 Sense2GO | Low| No | Low
  XMC1400 Arduino Kit | Low | Yes | High
  XMC4200 Platform2Go | High| No | High
  XMC4400 Platform2Go | High| No | High
  XMC4700 Relax Kit | High| No | High
  XMC4700 Relax Kit Lite | High| No | High
 
+** NOTE ** After Version 2.0 of XMC-for-Arduino, some boards were dropped (e.g. XMC1300 Sense2GO) they are still shown here for those using old versions of XMC-for-Arduino, and for history.
+
 [Back to top](#table-of-contents)
 ### LEDs on Different Boards
 Matrix of available on board LED names or LED they map to, known currently.
 
-| LED Macro | XMC1100 <BR>Boot Kit | XMC1100 <BR>XMC2GO | XMC1100 <BR>HBRIDGE2GO | XMC1300 <BR>Boot Kit | XMC1300 <BR>Sense2GOL | XMC1400 <br>Arduino Kit | XMC4200 <br>Platform2Go | XMC4400 <br>Platform2Go | XMC4700 <BR>Relax Kit | XMC4700 <BR>Relax Kit Lite |
+| LED Macro | XMC1100 <BR>Boot Kit | XMC1100 <BR>XMC2GO | XMC1100 <BR>HBRIDGE2GO | XMC1300 <BR>Boot Kit | XMC1300 <BR>Sense2GO | XMC1400 <br>Arduino Kit | XMC4200 <br>Platform2Go | XMC4400 <br>Platform2Go | XMC4700 <BR>Relax Kit | XMC4700 <BR>Relax Kit Lite |
 | --- | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: |
  LED_BUILTIN | Y | LED1 | LED1 | LED1 | LED1 | Y | LED1 | LED1 | LED1 | LED1
  LED1 | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y

--- a/libraries/LED/library.properties
+++ b/libraries/LED/library.properties
@@ -1,6 +1,6 @@
 name=LED
-version=1.0.3
-author=Infineon Technologies AG
+version=1.0.4
+author=Paul Carpenter, PC services, www.pcserviceselectronics.co.uk
 maintainer=Infineon Technologies AG <www.infineon.com>
 sentence=This library allows you to enable as well as control the on board LEDs of the XMC microcontrollers.
 paragraph= This library allows you to enable as well as control the on boards LEDs on Infineon XMC boards, in a way that works across ANY board.

--- a/libraries/LED/src/LED.cpp
+++ b/libraries/LED/src/LED.cpp
@@ -61,14 +61,28 @@ pinMode( pin, OUTPUT );
 /* Set LED On for specified pin */
 void LED::On( int pin )
 {
-digitalWrite( pin, XMC_LED_ON );
+if( pin == LED_BUILTIN )
+#ifdef XMC_LED_BUILTIN_REVERSED
+  digitalWrite( pin, false );
+#else
+  digitalWrite( pin, true );
+#endif
+else
+  digitalWrite( pin, XMC_LED_ON );
 }
 
 
 /* Set LED Off for specified pin */
 void LED::Off( int pin )
 {
-digitalWrite( pin, !XMC_LED_ON );
+if( pin == LED_BUILTIN )
+#ifdef XMC_LED_BUILTIN_REVERSED
+  digitalWrite( pin, true );
+#else
+  digitalWrite( pin, false );
+#endif
+else
+  digitalWrite( pin, !XMC_LED_ON );
 }
 
 

--- a/variants/XMC1300/config/XMC1300_Boot_Kit/pins_arduino.h
+++ b/variants/XMC1300/config/XMC1300_Boot_Kit/pins_arduino.h
@@ -40,6 +40,8 @@
 
 /* On board LED is ON when digital output is 0, LOW, False, OFF */
 #define  XMC_LED_ON         0
+/* On board LED_BUILTIN is NOT standard LED is ON when digital output is 0, LOW, False, OFF */
+#define  XMC_LED_BUILTIN_REVERSED 1
 
 // Following were defines now evaluated by compilation as const variables
 // After definitions of associated mapping arrays


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
On XMC1300 Boot Kit the LED_Builtin is reversed to normal Arduino standard. On all other boards LED_BUILTIN works as per Arduino standard, but maybe different to XMC_LED_ON setting, this corrects both situations.

This V2.x version of previous PR for develop1.x for LED library