### PR TITLE
GPIO Init after USIC CH Start

### DIFF
--- a/cores/HardwareSerial.cpp
+++ b/cores/HardwareSerial.cpp
@@ -56,8 +56,6 @@ uart_ch_config.stop_bits = (uint8_t)(( config & 0x0f0U ) >> 4 );
 
 XMC_UART_CH_Init( _XMC_UART_config->channel, &uart_ch_config );
 
-XMC_GPIO_Init( _XMC_UART_config->rx.port, _XMC_UART_config->rx.pin, &(_XMC_UART_config->rx_config) );
-
 // dx0 is UART RX: source must be set
 XMC_USIC_CH_SetInputSource( _XMC_UART_config->channel, XMC_USIC_CH_INPUT_DX0, 
                             _XMC_UART_config->input_source_dx0 );
@@ -92,10 +90,13 @@ XMC_USIC_CH_SetInterruptNodePointer(_XMC_UART_config->channel,
                                         _XMC_UART_config->irq_service_request );
 NVIC_SetPriority(_XMC_UART_config->irq_num, 3);
 NVIC_EnableIRQ(_XMC_UART_config->irq_num);
+
+XMC_UART_CH_Start( _XMC_UART_config->channel );
+
 // TX pin setup put here to avoid startup corrupted characters being first sent
 XMC_GPIO_Init( _XMC_UART_config->tx.port, _XMC_UART_config->tx.pin, &(_XMC_UART_config->tx_config) );
 
-XMC_UART_CH_Start( _XMC_UART_config->channel );
+XMC_GPIO_Init( _XMC_UART_config->rx.port, _XMC_UART_config->rx.pin, &(_XMC_UART_config->rx_config) );
 }
 
 

--- a/libraries/SPI/src/HW_SPI.cpp
+++ b/libraries/SPI/src/HW_SPI.cpp
@@ -99,11 +99,11 @@ void SPIClass::init()
     /* Configure the data input line selected */
     XMC_SPI_CH_SetInputSource(XMC_SPI_config->channel, XMC_SPI_CH_INPUT_DIN0, (uint8_t)XMC_SPI_config->input_source);
 
-    /* Initialize SPI SCLK out pin */
-    XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_SPI_config->sclkout.port, (uint8_t)XMC_SPI_config->sclkout.pin, &(XMC_SPI_config->sclkout_config));
-
     /* Start the SPI_Channel */
     XMC_SPI_CH_Start(XMC_SPI_config->channel);
+
+    /* Initialize SPI SCLK out pin */
+    XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_SPI_config->sclkout.port, (uint8_t)XMC_SPI_config->sclkout.pin, &(XMC_SPI_config->sclkout_config));
 
     /* Configure the input pin properties */
     XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_SPI_config->miso.port, (uint8_t)XMC_SPI_config->miso.pin, &(XMC_SPI_config->miso_config));

--- a/libraries/SPI/src/HW_SPI.cpp
+++ b/libraries/SPI/src/HW_SPI.cpp
@@ -99,17 +99,17 @@ void SPIClass::init()
     /* Configure the data input line selected */
     XMC_SPI_CH_SetInputSource(XMC_SPI_config->channel, XMC_SPI_CH_INPUT_DIN0, (uint8_t)XMC_SPI_config->input_source);
 
-    /* Configure the input pin properties */
-    XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_SPI_config->miso.port, (uint8_t)XMC_SPI_config->miso.pin, &(XMC_SPI_config->miso_config));
-
-    /* Configure the output pin properties */
-    XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_SPI_config->mosi.port, (uint8_t)XMC_SPI_config->mosi.pin, &(XMC_SPI_config->mosi_config));
-
     /* Initialize SPI SCLK out pin */
     XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_SPI_config->sclkout.port, (uint8_t)XMC_SPI_config->sclkout.pin, &(XMC_SPI_config->sclkout_config));
 
     /* Start the SPI_Channel */
     XMC_SPI_CH_Start(XMC_SPI_config->channel);
+
+    /* Configure the input pin properties */
+    XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_SPI_config->miso.port, (uint8_t)XMC_SPI_config->miso.pin, &(XMC_SPI_config->miso_config));
+
+    /* Configure the output pin properties */
+    XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_SPI_config->mosi.port, (uint8_t)XMC_SPI_config->mosi.pin, &(XMC_SPI_config->mosi_config));
 
     interruptMode = SPI_IMODE_NONE;
     interruptSave = 0;
@@ -122,27 +122,7 @@ void SPIClass::end()
     // Only disable HW when USIC is used for SPI
 	if((XMC_SPI_config->channel->CCR & USIC_CH_CCR_MODE_Msk) == XMC_USIC_CH_OPERATING_MODE_SPI)
 	{
-		XMC_GPIO_CONFIG_t default_input_port_config = {
-            .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
-            .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-#if UC_FAMILY == XMC1
-            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD
-#endif
-        };
-		
-		XMC_GPIO_CONFIG_t default_output_port_config = {
-            .mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL,
-            .output_level = XMC_GPIO_OUTPUT_LEVEL_LOW,
-#if UC_FAMILY == XMC1
-            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD
-#endif
-        };
-
 		XMC_SPI_CH_Stop(XMC_SPI_config->channel);
-
-		XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_SPI_config->miso.port, (uint8_t)XMC_SPI_config->miso.pin, &default_input_port_config);
-		XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_SPI_config->mosi.port, (uint8_t)XMC_SPI_config->mosi.pin, &default_output_port_config);
-		XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_SPI_config->sclkout.port, (uint8_t)XMC_SPI_config->sclkout.pin, &default_output_port_config);
 
 		XMC_SPI_config->channel->DXCR[XMC_USIC_CH_INPUT_DX0] = (uint32_t)(XMC_SPI_config->channel->DXCR[XMC_USIC_CH_INPUT_DX0] | (USIC_CH_DX0CR_DSEN_Msk)) & (~USIC_CH_DX0CR_INSW_Msk);
 		XMC_USIC_CH_SetInputSource(XMC_SPI_config->channel, XMC_USIC_CH_INPUT_DX0, XMC_INPUT_A);

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -96,10 +96,7 @@ void TwoWire::begin(void)
   							   0,
   							   XMC_USIC_CH_FIFO_SIZE_16WORDS,
   								(uint32_t)(15));
-
-    XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_I2C_config->sda.port, (uint8_t)XMC_I2C_config->sda.pin, &(XMC_I2C_config->sda_config));
-    XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_I2C_config->scl.port, (uint8_t)XMC_I2C_config->scl.pin, &(XMC_I2C_config->scl_config));
-	
+    
     XMC_USIC_CH_SetInterruptNodePointer(XMC_I2C_config->channel,
                                         XMC_USIC_CH_INTERRUPT_NODE_POINTER_PROTOCOL,
                                         XMC_I2C_config->protocol_irq_service_request);
@@ -109,6 +106,9 @@ void TwoWire::begin(void)
     XMC_I2C_CH_EnableEvent(XMC_I2C_config->channel, (uint32_t)(XMC_I2C_CH_EVENT_NACK | XMC_I2C_CH_EVENT_DATA_LOST | XMC_I2C_CH_EVENT_ARBITRATION_LOST | XMC_I2C_CH_EVENT_ERROR));
 
     XMC_I2C_CH_Start(XMC_I2C_config->channel);
+    
+    XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_I2C_config->sda.port, (uint8_t)XMC_I2C_config->sda.pin, &(XMC_I2C_config->sda_config));
+    XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_I2C_config->scl.port, (uint8_t)XMC_I2C_config->scl.pin, &(XMC_I2C_config->scl_config));
 }
 
 void TwoWire::begin(uint8_t address)
@@ -125,9 +125,6 @@ void TwoWire::begin(uint8_t address)
 
     XMC_USIC_CH_SetInputSource(XMC_I2C_config->channel, XMC_USIC_CH_INPUT_DX0, XMC_I2C_config->input_source_dx0);
     XMC_USIC_CH_SetInputSource(XMC_I2C_config->channel, XMC_USIC_CH_INPUT_DX1, XMC_I2C_config->input_source_dx1);
-
-    XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_I2C_config->sda.port, (uint8_t)XMC_I2C_config->sda.pin, &(XMC_I2C_config->sda_config));
-    XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_I2C_config->scl.port, (uint8_t)XMC_I2C_config->scl.pin, &(XMC_I2C_config->scl_config));
 
     XMC_USIC_CH_SetInterruptNodePointer(XMC_I2C_config->channel,
                                         XMC_USIC_CH_INTERRUPT_NODE_POINTER_RECEIVE,
@@ -154,6 +151,9 @@ void TwoWire::begin(uint8_t address)
     XMC_I2C_CH_EnableEvent(XMC_I2C_config->channel, (uint32_t)((uint32_t)XMC_I2C_CH_EVENT_SLAVE_READ_REQUEST | (uint32_t)XMC_I2C_CH_EVENT_STOP_CONDITION_RECEIVED));
 
     XMC_I2C_CH_Start(XMC_I2C_config->channel);
+
+    XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_I2C_config->sda.port, (uint8_t)XMC_I2C_config->sda.pin, &(XMC_I2C_config->sda_config));
+    XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_I2C_config->scl.port, (uint8_t)XMC_I2C_config->scl.pin, &(XMC_I2C_config->scl_config));
 }
 
 void TwoWire::begin(int address)
@@ -166,19 +166,7 @@ void TwoWire::end(void)
     //  Only disable HW when USIC is used for I2C
 	if((XMC_I2C_config->channel->CCR & USIC_CH_CCR_MODE_Msk) == XMC_USIC_CH_OPERATING_MODE_I2C)
 	{
-        
-        XMC_GPIO_CONFIG_t default_output_port_config = {
-            .mode = XMC_GPIO_MODE_OUTPUT_OPEN_DRAIN,
-            .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-#if UC_FAMILY == XMC1
-            .input_hysteresis = XMC_GPIO_INPUT_HYSTERESIS_STANDARD
-#endif
-        };
-
-		XMC_I2C_CH_Stop(XMC_I2C_config->channel);
-
-		XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_I2C_config->sda.port, (uint8_t)XMC_I2C_config->sda.pin, &default_output_port_config);
-		XMC_GPIO_Init((XMC_GPIO_PORT_t*)XMC_I2C_config->scl.port, (uint8_t)XMC_I2C_config->scl.pin, &default_output_port_config);
+        XMC_I2C_CH_Stop(XMC_I2C_config->channel);
 
 		XMC_USIC_CH_SetInputSource(XMC_I2C_config->channel, XMC_USIC_CH_INPUT_DX0, XMC_INPUT_A);
 		XMC_USIC_CH_SetInputSource(XMC_I2C_config->channel, XMC_USIC_CH_INPUT_DX1, XMC_INPUT_A);


### PR DESCRIPTION
Put the GPIO_Init() after CH_Start for SPI, I2C and HardwareSerial in order to avoid false pulses as described in issue #234 

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
With this PR the GPIO_Init() functions are moved after XMC_CH_Start() of I2C, SPI and HardwareSerial.
This solves the issue #234 with wrong pulses output on the communication lines.
Also in the respective end() functions

Related Issue
#234 