### PR TITLE
added wait for ACK after a I2C transaction

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -245,6 +245,8 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
         XMC_I2C_CH_MasterStart(XMC_I2C_config->channel, (txAddress << 1), XMC_I2C_CH_CMD_READ);
     }
 
+    while((XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel) & XMC_I2C_CH_STATUS_FLAG_ACK_RECEIVED) == 0U);
+
     for (uint8_t count = 0; count < (quantity - 1); count ++)
     {
         XMC_I2C_CH_MasterReceiveAck(XMC_I2C_config->channel);

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -246,10 +246,11 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
     }
 
     timeout = WIRE_COMMUNICATION_TIMEOUT;
-
+    // wait for ACK or timeout incase no ACK is received, a time-based wait-state is added since XMC devices run at variable frequencies
     while(((XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel) & XMC_I2C_CH_STATUS_FLAG_ACK_RECEIVED) == 0U) || timeout == 0)
     {
-    timeout--;
+        delay(1);
+        timeout--;
     }
 
     for (uint8_t count = 0; count < (quantity - 1); count ++)

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -245,7 +245,12 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
         XMC_I2C_CH_MasterStart(XMC_I2C_config->channel, (txAddress << 1), XMC_I2C_CH_CMD_READ);
     }
 
-    while((XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel) & XMC_I2C_CH_STATUS_FLAG_ACK_RECEIVED) == 0U);
+    timeout = WIRE_COMMUNICATION_TIMEOUT;
+
+    while(((XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel) & XMC_I2C_CH_STATUS_FLAG_ACK_RECEIVED) == 0U) || timeout == 0)
+    {
+    timeout--;
+    }
 
     for (uint8_t count = 0; count < (quantity - 1); count ++)
     {


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Added wait in I2C transaction

Context
Added a wait state until ACK is received after sending a START or REP_START. This was absent before so it leads to a intermittent erroneous reading from I2C sensors.