### PR TITLE
Sd card change

### DIFF
--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -35,8 +35,11 @@
 //#define USE_SW_SPI
 
 // Define USE_XMC_RELAX_KIT_SD allows to use the SD Lib to communicate with a SD Card over
-// the on-board SD Card Slot
-//#define USE_XMC_RELAX_KIT_SD
+// the on-board SD Card Slot. This feature is only available on XMC4700 RelaxKits.
+#if defined(XMC4700_Relax_Kit)
+    #define USE_XMC_RELAX_KIT_SD
+#endif
+
 
 #define SPI_MODE0 0x00
 #define SPI_MODE1 0x01

--- a/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
+++ b/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
@@ -86,10 +86,10 @@ extern uint8_t MOSI;
 extern uint8_t MISO;
 extern uint8_t SCK;
 
-#define PIN_SPI_SS_SD    28
-#define PIN_SPI_MOSI_SD  29
-#define PIN_SPI_MISO_SD  30
-#define PIN_SPI_SCK_SD   31
+#define PIN_SPI_SS_SD    26
+#define PIN_SPI_MOSI_SD  27
+#define PIN_SPI_MISO_SD  28
+#define PIN_SPI_SCK_SD   29
 
 static const uint8_t SS_SD   = PIN_SPI_SS_SD;
 static const uint8_t MOSI_SD = PIN_SPI_MOSI_SD;


### PR DESCRIPTION
This changes will make the SD card on XMC4700 RelaxKits available. Therefore the right SPI pins must be set and a macro for the XMC4700 RelaxKit has to be set. 

Keep in mind that only certain versions of the XMC4700 have the on board SD card slot. Therefore switch on the macro in SPI.h if you don't need it. 

This change has no effect on any other XMC series.
