### PR TITLE
Fix wrong XMC1300 Boot Kit identifier in xmc_data.py

### DIFF
--- a/tools/xmc_data.py
+++ b/tools/xmc_data.py
@@ -29,7 +29,7 @@ xmc_master_data = {
          "bitposition_LSB":"12"
       }
    },
-   "XMC1300-0200":{
+   "XMC1302-0200":{
       "IDCHIP":{
          "addr":"40010004",
          "size":"4",


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description

XMC for Arduino do not work with XMC1300 Boot Kit (which uses XMC130**2** Microcontroller). Uploading sketch ends up with following error with curious description:

```
Traceback (most recent call last):
  File "C:\Users\michal\AppData\Local\Arduino15\packages\Infineon\hardware\xmc\3.0.0/tools/xmc-flasher.py", line 263, in <module>
    parser()
  File "C:\Users\michal\AppData\Local\Arduino15\packages\Infineon\hardware\xmc\3.0.0/tools/xmc-flasher.py", line 258, in parser
    args.func(args) 
  File "C:\Users\michal\AppData\Local\Arduino15\packages\Infineon\hardware\xmc\3.0.0/tools/xmc-flasher.py", line 217, in parser_upload_func
    check_device(args.device, args.port)
  File "C:\Users\michal\AppData\Local\Arduino15\packages\Infineon\hardware\xmc\3.0.0/tools/xmc-flasher.py", line 148, in check_device
    device_value = get_mem_contents(master_data[device]['IDCHIP']['addr'], master_data[device]['IDCHIP']['size'], device, port)
KeyError: 'XMC1302-0200'
Failed uploading: uploading error: exit status 1
```

Root cause is that xmc_data.py which contains definition of some address for each supported board has wrong identifier of XMC1300 Boot Kit.

This push request fix it.