### PR TITLE
DESMAKERS-3827: enable 11/29Bits id frame send and receive

### DIFF
--- a/cores/Arduino.h
+++ b/cores/Arduino.h
@@ -263,7 +263,8 @@ extern "C" {
     typedef struct 
     {
       CAN_NODE_TypeDef              *can_node;
-      XMC_CAN_NODE_NUM_t            can_node_num;  
+      XMC_CAN_NODE_NUM_t            can_node_num;
+      XMC_CAN_CANCLKSRC_t           can_clock;
       uint32_t                      can_frequency;
       XMC_PORT_PIN_t                rx;
       XMC_GPIO_CONFIG_t             rx_config;

--- a/libraries/CAN/README_CAN.md
+++ b/libraries/CAN/README_CAN.md
@@ -24,13 +24,6 @@ Returns `1` on success, `0` on failure.
 
 The RX and TX pins are determined. 
 
-### Set identifier
-
-```arduino
-  CAN.setIdentifier(id);
-```
- * `id` - 11 bits standard identifier. Reflecting the contents and priority of the message. (default: `0x12`)
-
 
 ### End
 
@@ -51,9 +44,13 @@ Start the sequence of sending a packet.
 CAN.beginPacket(id);
 CAN.beginPacket(id, dlc);
 CAN.beginPacket(id, dlc, rtr);
+
+CAN.beginExtendedPacket(id);
+CAN.beginExtendedPacket(id, dlc);
+CAN.beginExtendedPacket(id, dlc, rtr);
 ```
 
- * `id` - 11-bit id (standard packet) <strike> or 29-bit packet id (extended packet)</strike>
+ * `id` - 11-bit id (standard packet) or 29-bit packet id (extended packet)
  * `dlc` - (optional) value of Data Length Code (DLC) field of packet, default is size of data written in packet
  * `rtr` - (optional) value of Remote Transmission Request (RTR) field of packet (`false` or `true`), defaults to `false`. RTR packets contain no data, the DLC field of the packet represents the requested length.
 
@@ -96,8 +93,9 @@ Returns `1` on success, `0` on failure.
 Check if a packet has been received.
 
 ```arduino
-int packetSize = CAN.parsePacket();
+int packetSize = CAN.parsePacket(id);
 ```
+ * `id` - 11-bit id (standard packet) or 29-bit packet id (extended packet)
 
 Returns the packet size in bytes or `0` if no packet was received. For RTR packets the size reflects the DLC field of the packet.
 

--- a/libraries/CAN/examples/CANReceiver/CANReceiver.ino
+++ b/libraries/CAN/examples/CANReceiver/CANReceiver.ino
@@ -15,7 +15,6 @@ void setup() {
     Serial.println("Starting CAN failed!");
     while (1);
   }
-  CAN.setIdentifier(0x12);
 }
 
 void loop() {

--- a/libraries/CAN/examples/CANReceiverCallback/CANReceiverCallback.ino
+++ b/libraries/CAN/examples/CANReceiverCallback/CANReceiverCallback.ino
@@ -18,7 +18,6 @@ void setup() {
 
   // register the receive callback
   CAN.onReceive(onReceive);
-  CAN.setIdentifier(0x12);
 }
 
 void loop() {

--- a/libraries/CAN/examples/CANSender/CANSender.ino
+++ b/libraries/CAN/examples/CANSender/CANSender.ino
@@ -33,7 +33,7 @@ void loop() {
 
   delay(1000);
 
-  CAN.beginPacket(0x12);
+  CAN.beginExtendedPacket(0xFFF);
   CAN.write('w');
   CAN.write('o');
   CAN.write('r');

--- a/libraries/CAN/src/CANXMC.cpp
+++ b/libraries/CAN/src/CANXMC.cpp
@@ -4,12 +4,12 @@
 
 namespace ifx {
 
-/* CAN Receive Message Object definition */
+/* CAN Receive Message Object definition, can also be used for transmit remote frame*/
 XMC_CAN_MO_t CAN_msg_rx = {
     .can_mo_ptr = (CAN_MO_TypeDef *)CAN_MO0,
     {0xFF, XMC_CAN_FRAME_TYPE_STANDARD_11BITS, // {can_identifier, can_id_mode
      XMC_CAN_ARBITRATION_MODE_ORDER_BASED_PRIO_1}, // can_priority}
-    {0xFFU, 1U}, // {can_id_mask, can_ide_mask}
+    {0x000, 1U}, // {can_id_mask, can_ide_mask}
     .can_data_length = 0U,
     .can_mo_type = XMC_CAN_MO_TYPE_RECMSGOBJ,
 };
@@ -48,12 +48,14 @@ CANXMC::~CANXMC() {}
         .sample_point = (uint16_t)(80 * 100),
         .sjw = (uint16_t)1,
     };
+
     XMC_CAN_Enable(CAN_xmc);
+
      /* Configuration of CAN Node and enable the clock */ 
     #if (UC_FAMILY == XMC4)
-      #define CAN_CLOCK_SOURCE ((XMC_CAN_CANCLKSRC_t)XMC_CAN_CANCLKSRC_FPERI) 
+      #define CAN_CLOCK_SOURCE ((XMC_CAN_CANCLKSRC_t)XMC_CAN_CANCLKSRC_FPERI) // synchronous clock for XMC4000
     #else
-      #define CAN_CLOCK_SOURCE ((XMC_CAN_CANCLKSRC_t)XMC_CAN_CANCLKSRC_MCLK)
+      #define CAN_CLOCK_SOURCE ((XMC_CAN_CANCLKSRC_t)XMC_CAN_CANCLKSRC_MCLK) // synchronous clock for XMC1400
     #endif
     XMC_CAN_InitEx(CAN_xmc, CAN_CLOCK_SOURCE, _XMC_CAN_config->can_frequency); 
     if(XMC_CAN_STATUS_SUCCESS == XMC_CAN_NODE_NominalBitTimeConfigureEx(_XMC_CAN_config->can_node, &CAN_NODE_bit_time_config))
@@ -69,6 +71,7 @@ CANXMC::~CANXMC() {}
       XMC_GPIO_SetHardwareControl(_XMC_CAN_config->rx.port, _XMC_CAN_config->rx.pin, XMC_GPIO_HWCTRL_DISABLED);
       XMC_CAN_NODE_SetReceiveInput(_XMC_CAN_config->can_node, _XMC_CAN_config->node_input);
       
+      /* Allocate the rx and tx message object*/
       XMC_CAN_MO_Config(&CAN_msg_rx);
       XMC_CAN_AllocateMOtoNodeList(CAN_xmc, _XMC_CAN_config->can_node_num, 0);
       XMC_CAN_MO_Config(&CAN_msg_tx);
@@ -76,12 +79,12 @@ CANXMC::~CANXMC() {}
     
       /* Message object accepts the reception of both, standard and extended frames */
       XMC_CAN_MO_AcceptStandardAndExtendedID(&CAN_msg_rx);
-      // CAN_msg_rx.can_ide_mask = 0U;
-      // CAN_msg_rx.can_mo_ptr->MOAMR = 0x3fffffff & ~(uint32_t)(CAN_MO_MOAMR_MIDE_Msk);
+
 #if (UC_SERIES == XMC14)
     // select interrupt source (A,B,C etc) input to NVIC node (only for XMC1400 devices)  
       XMC_SCU_SetInterruptControl(_XMC_CAN_config->irq_num, _XMC_CAN_config->irq_source);
-#endif    
+#endif
+
       XMC_CAN_MO_SetEventNodePointer(&CAN_msg_rx, XMC_CAN_MO_POINTER_EVENT_RECEIVE, _XMC_CAN_config->irq_service_request);
       XMC_CAN_MO_EnableEvent(&CAN_msg_rx, XMC_CAN_MO_EVENT_RECEIVE);
 
@@ -101,7 +104,6 @@ CANXMC::~CANXMC() {}
     XMC_CAN_MO_DisableEvent(&CAN_msg_rx, XMC_CAN_MO_EVENT_RECEIVE);
     XMC_CAN_Disable(CAN_xmc);
     CANControllerClass::end();
-
   };
 
   int CANXMC::endPacket() {
@@ -109,11 +111,20 @@ CANXMC::~CANXMC() {}
       return 0;
     }
 
+    /* setup message object */
+    if (_txExtended) {
+      XMC_CAN_MO_SetExtendedID(&CAN_msg_tx);
+    } else {
+      XMC_CAN_MO_SetStandardID(&CAN_msg_tx);
+    }
+    XMC_CAN_MO_SetIdentifier(&CAN_msg_tx, _txId);
     if (!_txRtr) {
       memcpy(CAN_msg_tx.can_data_byte, _txData, _txLength);
     }
+    
     XMC_CAN_MO_SetDataLengthCode(&CAN_msg_tx, _txLength);
-    XMC_CAN_MO_SetIdentifier(&CAN_msg_tx, _txId);
+
+
 
     /* Configure data to be transmitted and data length code */
     XMC_CAN_MO_UpdateData(&CAN_msg_tx);
@@ -131,11 +142,9 @@ CANXMC::~CANXMC() {}
   int CANXMC::parsePacket()
   {  
     while((XMC_CAN_MO_GetStatus(&CAN_msg_rx) & CAN_MO_MOSTAT_NEWDAT_Msk) >> CAN_MO_MOSTAT_NEWDAT_Pos != 1);
-      // XMC_CAN_MO_UpdateData(&CAN_msg_rx);
       XMC_CAN_MO_Receive(&CAN_msg_rx);
 
-
-      // check CAN frame type
+      /* check CAN frame type */
       _rxId = XMC_CAN_MO_GetIdentifier(&CAN_msg_rx);
 
       if (CAN_msg_rx.can_id_mode == XMC_CAN_FRAME_TYPE_EXTENDED_29BITS){
@@ -152,9 +161,9 @@ CANXMC::~CANXMC() {}
       _rxLength = _rxDlc;
       memcpy(_rxData, CAN_msg_rx.can_data_byte, _rxLength);
   	  }
-    // set the flag back and wait for next receive 
+    /* set the flag back and wait for next receive */
     can_frame_received = false;
-    // XMC_CAN_MO_SetDataLengthCode(&CAN_msg_rx, 0U); 
+
     _rxIndex = 0;
     
     return _rxLength;

--- a/libraries/CAN/src/CANXMC.cpp
+++ b/libraries/CAN/src/CANXMC.cpp
@@ -19,7 +19,7 @@ XMC_CAN_MO_t CAN_msg_tx = {
     .can_mo_ptr = (CAN_MO_TypeDef *)CAN_MO1,
     {0xFF, XMC_CAN_FRAME_TYPE_STANDARD_11BITS, // {can_identifier, can_id_mode
      XMC_CAN_ARBITRATION_MODE_ORDER_BASED_PRIO_1}, // can_priority}
-    {0xFFU, 1U}, // {can_id_mask, can_ide_mask}
+    {0x7FFU, 1U}, // {can_id_mask, can_ide_mask}
     .can_data_length = 1U,
     .can_mo_type = XMC_CAN_MO_TYPE_TRANSMSGOBJ,
 };
@@ -52,12 +52,7 @@ CANXMC::~CANXMC() {}
     XMC_CAN_Enable(CAN_xmc);
 
      /* Configuration of CAN Node and enable the clock */ 
-    #if (UC_FAMILY == XMC4)
-      #define CAN_CLOCK_SOURCE ((XMC_CAN_CANCLKSRC_t)XMC_CAN_CANCLKSRC_FPERI) // synchronous clock for XMC4000
-    #else
-      #define CAN_CLOCK_SOURCE ((XMC_CAN_CANCLKSRC_t)XMC_CAN_CANCLKSRC_MCLK) // synchronous clock for XMC1400
-    #endif
-    XMC_CAN_InitEx(CAN_xmc, CAN_CLOCK_SOURCE, _XMC_CAN_config->can_frequency); 
+    XMC_CAN_InitEx(CAN_xmc, _XMC_CAN_config->can_clock , _XMC_CAN_config->can_frequency); 
     if(XMC_CAN_STATUS_SUCCESS == XMC_CAN_NODE_NominalBitTimeConfigureEx(_XMC_CAN_config->can_node, &CAN_NODE_bit_time_config))
     {
       XMC_CAN_NODE_EnableConfigurationChange(_XMC_CAN_config->can_node);

--- a/variants/XMC1400/config/XMC1400_XMC2GO/pins_arduino.h
+++ b/variants/XMC1400/config/XMC1400_XMC2GO/pins_arduino.h
@@ -378,6 +378,7 @@ XMC_I2S_t i2s_config =
 XMC_ARD_CAN_t XMC_CAN_0 = {
     .can_node = CAN_NODE0,
     .can_node_num = 0,
+    .can_clock = XMC_CAN_CANCLKSRC_MCLK,
     .can_frequency = (uint32_t)48000000,
     .rx = {.port = (XMC_GPIO_PORT_t *)PORT1_BASE, .pin = (uint8_t)1},
     .rx_config =

--- a/variants/XMC4200/config/XMC4200_Platform2GO/pins_arduino.h
+++ b/variants/XMC4200/config/XMC4200_Platform2GO/pins_arduino.h
@@ -381,6 +381,7 @@ XMC_ARD_CAN_t XMC_CAN_0 =
 {
  .can_node = CAN_NODE0,
  .can_node_num = 0,
+ .can_clock = XMC_CAN_CANCLKSRC_FPERI,
  .can_frequency = (uint32_t)144000000,
  .rx = {  .port = (XMC_GPIO_PORT_t*)PORT14_BASE,
           .pin  = (uint8_t)3

--- a/variants/XMC4400/config/XMC4400_Platform2GO/pins_arduino.h
+++ b/variants/XMC4400/config/XMC4400_Platform2GO/pins_arduino.h
@@ -433,6 +433,7 @@ XMC_ARD_CAN_t XMC_CAN_0 =
 {
  .can_node = CAN_NODE1,
  .can_node_num = 1,
+ .can_clock = XMC_CAN_CANCLKSRC_FPERI,
  .can_frequency = (uint32_t)144000000,
  .rx = {  .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
           .pin  = (uint8_t)13

--- a/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
+++ b/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
@@ -714,6 +714,7 @@ XMC_ARD_CAN_t XMC_CAN_0 =
 {
  .can_node = CAN_NODE1,
  .can_node_num = 1,
+ .can_clock = XMC_CAN_CANCLKSRC_FPERI,
  .can_frequency = (uint32_t)144000000,
  .rx = {  .port = (XMC_GPIO_PORT_t*)PORT1_BASE,
           .pin  = (uint8_t)13


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Now sendpacket() support both 11 & 29 bits identifier. same for receive. 
Functions that are not the same as the official API can be removed, updating the README and example sketches.

Related Issue
N/A

Context
Once it's up and running, it works ;)