### PR TITLE
Fix: automatically select default port and remove mojibake

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -147,12 +147,12 @@ recipe.size.regex.data=^(?:\.data|\.VENEER_Code|\.ram_code|\.bss|\.no_init|\Stac
 # ----------------
 tools.xmcflasher.path={runtime.platform.path}/tools
 tools.xmcflasher.cmd.path={path}/xmc-flasher.py
-tools.xmcflasher.erase.params=-d XMC{build.board.version}-{build.board.v} -p {serial.port}
+tools.xmcflasher.erase.params=-d XMC{build.board.version}-{build.board.v} -p {upload.port.address}
 tools.xmcflasher.erase.pattern=python3 {cmd.path} erase {erase.params}
 tools.xmcflasher.erase.pattern.windows=python {cmd.path} erase {erase.params}
 tools.xmcflasher.upload.protocol=
 tools.xmcflasher.upload.params.verbose=--verbose
 tools.xmcflasher.upload.params.quiet=
-tools.xmcflasher.upload.params=-d XMC{build.board.version}-{build.board.v} -p {serial.port} -f {build.path}/{build.project_name}.hex {upload.verbose}
+tools.xmcflasher.upload.params=-d XMC{build.board.version}-{build.board.v} -p {upload.port.address} -f {build.path}/{build.project_name}.hex {upload.verbose}
 tools.xmcflasher.upload.pattern=python3 {cmd.path} upload {upload.params}
 tools.xmcflasher.upload.pattern.windows=python {cmd.path} upload {upload.params}

--- a/tools/xmc-flasher.py
+++ b/tools/xmc-flasher.py
@@ -267,6 +267,10 @@ def parser():
                 else:
                     print("Upload failed.")
             remove_console_output_file(console_out)
+                                # Log if the port value has changed
+        if args.port != original_port:
+            print(f"Please select port {args.port} for using the Serial Monitor or Plotter.")
+        
 
     def parser_erase_func(args):
         erase(args.device, args.port)
@@ -311,6 +315,9 @@ def parser():
         sys.tracebacklimit = None  # Enable full traceback
     else:
         sys.tracebacklimit = 0  # Disable traceback
+
+    # Store the original port value
+    original_port = args.port
 
     # Select default port if not provided/ or device not found on the selected port
     args.port = get_default_port(args.port)

--- a/tools/xmc-flasher.py
+++ b/tools/xmc-flasher.py
@@ -178,7 +178,8 @@ def check_device(device, port):
     real_device = find_device_by_value(device_value_masked)
     #compare with stored master data
     if not real_device == device:
-        print(f"Connected Device is: {real_device}.")
+        if real_device != None:
+            print(f"Connected Device is: {real_device}.")
         raise Exception(f"Device connected on port {port} does not match the selected device to flash")
 
 def check_mem(device, port):
@@ -293,7 +294,7 @@ def parser():
     parser_upload = subparser.add_parser('upload', description='Upload binary command')
     required_upload = parser_upload.add_argument_group('required arguments')
     required_upload.add_argument('-d','--device', type=str, help='jlink device name', required=True)
-    required_upload.add_argument('-p','--port', type=str, help='serial port')
+    required_upload.add_argument('-p','--port', type=str, nargs='?', const='', help='serial port')
     required_upload.add_argument('-f','--binfile', type=str, help='binary file to upload', required=True)
     required_upload.add_argument('--verbose', action='store_true', help='Enable verbose logging')
     parser_upload.set_defaults(func=parser_upload_func)

--- a/tools/xmc-flasher.py
+++ b/tools/xmc-flasher.py
@@ -224,7 +224,7 @@ def get_default_port(port):
             if port_sn[1] != None:
                 real_port = port_sn[0]
                 print(f"Device found on port: {real_port}, not on the selected port: {port}.")
-                print(f"Please select correct port!")
+                print(f"Automatically selecting port {real_port}...")
                 return real_port
     else:
         return port

--- a/tools/xmc-flasher.py
+++ b/tools/xmc-flasher.py
@@ -81,6 +81,16 @@ def remove_console_output_file(console_output_file):
     if os.path.exists(console_output_file):
         os.remove(console_output_file)        
 
+def remove_backspaces(input_str):
+    result = []
+    for char in input_str:
+        if char == '\b':
+            if result:
+                result.pop()
+        else:
+            result.append(char)
+    return ''.join(result)
+
 def jlink_commander(device, serial_num, cmd_file, console_output=False):
     jlink_cmd = [jlinkexe, '-autoconnect', '1','-exitonerror', '1', '-nogui', '1', '-device', device, '-selectemubysn', serial_num, '-if', 'swd', '-speed', '4000', '-commandfile', cmd_file]
 
@@ -92,10 +102,10 @@ def jlink_commander(device, serial_num, cmd_file, console_output=False):
         if console_output is True:
             out, err = jlink_proc.communicate()
             with open(console_out, 'w') as f:
-                f.write(out)
+                f.write(remove_backspaces(out))
         else:
             for line in jlink_proc.stdout:
-                print(line, end='')
+                print(remove_backspaces(line), end='')
         jlink_proc.wait()
     except:
         raise Exception("jlink error")
@@ -156,12 +166,11 @@ def check_device(device, port):
     device_value_masked = f'{device_value_masked:x}'
     device_value_masked = device_value_masked.zfill(int(master_data[device]['IDCHIP']['size'])*2)
 
-    print(f"Device is: {device.split('-')[0]}.")
+    print(f"Selected Device is: {device.split('-')[0]}.")
    
     #compare with stored master data
     if not device_value_masked == master_data[device]['IDCHIP']['value']:
-        raise Exception("Device connected does not match the selected device to flash")
-
+        raise Exception(f"Device connected on port {port} does not match the selected device to flash")
 
 def check_mem(device, port):
     
@@ -196,7 +205,20 @@ def check_mem(device, port):
         #compare with stored master data
         if not device_value_masked.upper() == master_data[device]['FLASH0_ID']['value']:
             raise Exception("Memory size of device connected does not match that of the selected device to flash")
-
+        
+def get_default_port(port):
+    serial_num = get_device_serial_number(port)
+    if serial_num == None or port == None:
+        port_sn_list = discover_devices()
+        for port_sn in port_sn_list:
+            if port_sn[1] != None:
+                real_port = port_sn[0]
+                print(f"Device found on port: {real_port}, not on the selected port: {port}.")
+                print(f"Please select correct port!")
+                return real_port
+    else:
+        return port
+    
 
 def upload(device, port, binfile, enable_jlink_log):
     serial_num = get_device_serial_number(port)
@@ -258,7 +280,7 @@ def parser():
     parser_upload = subparser.add_parser('upload', description='Upload binary command')
     required_upload = parser_upload.add_argument_group('required arguments')
     required_upload.add_argument('-d','--device', type=str, help='jlink device name', required=True)
-    required_upload.add_argument('-p','--port', type=str, help='serial port', required=True)
+    required_upload.add_argument('-p','--port', type=str, help='serial port')
     required_upload.add_argument('-f','--binfile', type=str, help='binary file to upload', required=True)
     required_upload.add_argument('--verbose', action='store_true', help='Enable verbose logging')
     parser_upload.set_defaults(func=parser_upload_func)
@@ -280,6 +302,10 @@ def parser():
         sys.tracebacklimit = None  # Enable full traceback
     else:
         sys.tracebacklimit = 0  # Disable traceback
+
+    # Select default port if not provided/ or device not found on the selected port
+    args.port = get_default_port(args.port)
+
     # Parser call
     args.func(args) 
 

--- a/tools/xmc_data.py
+++ b/tools/xmc_data.py
@@ -47,8 +47,8 @@ xmc_master_data = {
       "IDCHIP":{
          "addr":"40010004",
          "size":"4",
-         "value":"00014000",
-         "mask":"FFFFF000"
+         "value":"00014020",
+         "mask":"000FFFF0"
       },
       "FLSIZE":{
          "addr":"40000404",
@@ -61,8 +61,8 @@ xmc_master_data = {
       "IDCHIP":{
          "addr":"40010004",
          "size":"4",
-         "value":"00014000",
-         "mask":"FFFFF000"
+         "value":"00014040",
+         "mask":"000FFFF0"
       },
       "FLSIZE":{
          "addr":"40000404",

--- a/tools/xmc_data.py
+++ b/tools/xmc_data.py
@@ -47,7 +47,7 @@ xmc_master_data = {
       "IDCHIP":{
          "addr":"40010004",
          "size":"4",
-         "value":"00014020",
+         "value":"00014010",
          "mask":"000FFFF0"
       },
       "FLSIZE":{


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Improve xmc flasher

Related Issue
DESMAKERS3766, DESMAKERS4040

Context
 - If no serial port is selected, pick first jlink device and log the right port 
 - Remove mojibake in uploading log


:no_entry: Synchronizing uploading windows of arduino IDE and the flasher script log as much as possible -> This delay also occurs when using arduino cli. It cannot be improved unless the arduino source code is changed