### PR TITLE
Fix: Cannot find JLink device in Linux 

### DIFF
--- a/tools/xmc-flasher.py
+++ b/tools/xmc-flasher.py
@@ -2,7 +2,7 @@ import argparse, subprocess, os, sys, re, warnings, tempfile
 from serial.tools.list_ports import comports
 from xmc_data import xmc_master_data
 
-version = '0.1.2'
+version = '0.1.3'
 
 jlinkexe = ''
 
@@ -40,8 +40,9 @@ def set_environment():
 def discover_jlink_devices():
     ports = comports()
     port_sn_list = []
+    jlink_pattern = r'[Jj][-\s]?[Ll][Ii][Nn][Kk]'
     for p in ports:
-        if "JLink" in p.description:
+        if re.search(jlink_pattern, p.description):
             port_sn_list.append((p.device, p.serial_number))
 
     return port_sn_list


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Error when flash in Linux. Adapt Regex expression
Thanks Olaf for finding this bug and providing a workaround

Related Issue
JLink device name is different for different OS.

Context
Tested on all OS

- [x] Windows
- [x] Linux
- [x] MacOS