### PR TITLE
Adapting timeout while-loop in Wire.cpp

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -244,10 +244,12 @@ uint8_t TwoWire::requestFrom(
     // wait for ACK or timeout incase no ACK is received, a time-based wait-state is added since XMC
     // devices run at variable frequencies
     while (((XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel) &
-             XMC_I2C_CH_STATUS_FLAG_ACK_RECEIVED) == 0U) ||
-           timeout == 0) {
+             XMC_I2C_CH_STATUS_FLAG_ACK_RECEIVED) == 0U)) {
         delay(1);
         timeout--;
+        if (timeout == 0) {
+            break;
+        }
     }
 
     for (uint8_t count = 0; count < (quantity - 1); count++) {


### PR DESCRIPTION
Error: Wire.cpp got stocked in the while-loop for the timeout since the timeout-condition was not defined as it should be per definition. It was not possible to leave the while-loop after the timeout-variable reached 0.

Change: Now, the checking condition was reduced to the essentials (it was wrong before) and another if-condition, which checks if the timeout-variable reached 0, was added inside the while-loop. This leads to a break.

Testing: The new wire.cpp was tested with the KIT_XMC_2GO_XMC1100_V1 & KIT_XMC47_RELAX_LITE_V1. Both worked.