### PR TITLE
Bugfix/desmakers 4316 spi normal pins 11 12 13 not functioning on xmc4700 relax kit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@ build
 **/__pycache__/
 venv/
 
-# code-check reports
+# code-check standards and reports
+misra.txt
 clang-tidy-report.txt
 
 scan-build-reports/

--- a/libraries/SPI/src/HW_SPI.cpp
+++ b/libraries/SPI/src/HW_SPI.cpp
@@ -29,10 +29,9 @@
 
     // swap SPI_default and SPI_for_xmc_SD if desired by user
     #if defined(USE_XMC_RELAX_KIT_SD) && defined(XMC_SPI_for_xmc_SD)
-SPIClass SPI(&XMC_SPI_for_xmc_SD);
-        #if (NUM_SPI > 1)
-SPIClass SPI1(&XMC_SPI_default);
-        #endif
+SPIClass SPI(&XMC_SPI_default);
+SPIClass SPI1(&XMC_SPI_for_xmc_SD);
+
 uint8_t SS = PIN_SPI_SS_SD;
 uint8_t MOSI = PIN_SPI_MOSI_SD;
 uint8_t MISO = PIN_SPI_MISO_SD;

--- a/libraries/SPI/src/HW_SPI.cpp
+++ b/libraries/SPI/src/HW_SPI.cpp
@@ -29,23 +29,20 @@
 
     // swap SPI_default and SPI_for_xmc_SD if desired by user
     #if defined(USE_XMC_RELAX_KIT_SD) && defined(XMC_SPI_for_xmc_SD)
-SPIClass SPI(&XMC_SPI_default);
-SPIClass SPI1(&XMC_SPI_for_xmc_SD);
-
-uint8_t SS = PIN_SPI_SS_SD;
-uint8_t MOSI = PIN_SPI_MOSI_SD;
-uint8_t MISO = PIN_SPI_MISO_SD;
-uint8_t SCK = PIN_SPI_SCK_SD;
+SPIClass SPI(&XMC_SPI_for_xmc_SD);
+        #if (NUM_SPI > 1)
+SPIClass SPI1(&XMC_SPI_default);
+        #endif
     #else // normal behaviour
 SPIClass SPI(&XMC_SPI_default);
         #if (NUM_SPI > 1)
 SPIClass SPI1(&XMC_SPI_1);
         #endif
+    #endif
 uint8_t SS = PIN_SPI_SS;
 uint8_t MOSI = PIN_SPI_MOSI;
 uint8_t MISO = PIN_SPI_MISO;
 uint8_t SCK = PIN_SPI_SCK;
-    #endif
 
     #if (NUM_SPI > 2)
 SPIClass SPI2(&XMC_SPI_2);

--- a/libraries/SPI/src/HW_SPI.cpp
+++ b/libraries/SPI/src/HW_SPI.cpp
@@ -29,10 +29,8 @@
 
     // swap SPI_default and SPI_for_xmc_SD if desired by user
     #if defined(USE_XMC_RELAX_KIT_SD) && defined(XMC_SPI_for_xmc_SD)
-SPIClass SPI(&XMC_SPI_for_xmc_SD);
-        #if (NUM_SPI > 1)
-SPIClass SPI1(&XMC_SPI_default);
-        #endif
+SPIClass SPI(&XMC_SPI_default);
+SPIClass SPI1(&XMC_SPI_for_xmc_SD);
     #else // normal behaviour
 SPIClass SPI(&XMC_SPI_default);
         #if (NUM_SPI > 1)

--- a/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
+++ b/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
@@ -86,15 +86,15 @@ extern uint8_t MOSI;
 extern uint8_t MISO;
 extern uint8_t SCK;
 
-#define PIN_SPI_SS_SD 26
-#define PIN_SPI_MOSI_SD 27
-#define PIN_SPI_MISO_SD 28
-#define PIN_SPI_SCK_SD 29
+#define SDCARD_SS_PIN 26
+#define SDCARD_MOSI_PIN 27
+#define SDCARD_MISO_PIN 28
+#define SDCARD_SCK_PIN 29
 
-static const uint8_t SS_SD = PIN_SPI_SS_SD;
-static const uint8_t MOSI_SD = PIN_SPI_MOSI_SD;
-static const uint8_t MISO_SD = PIN_SPI_MISO_SD;
-static const uint8_t SCK_SD = PIN_SPI_SCK_SD;
+static const uint8_t SS_SD = SDCARD_SS_PIN;
+static const uint8_t MOSI_SD = SDCARD_MOSI_PIN;
+static const uint8_t MISO_SD = SDCARD_MISO_PIN;
+static const uint8_t SCK_SD = SDCARD_SCK_PIN;
 
 // XMC_I2S defines
 /*U2C0*/

--- a/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
+++ b/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
@@ -62,7 +62,8 @@ extern const uint8_t NUM_ANALOG_OUTPUTS;
 #define NUM_I2C 2
 
 // to use SPI_for_xmc_SD if desired by user
-#define XMC_SPI_for_xmc_SD XMC_SPI_1
+#define XMC_SPI_for_xmc_SD XMC_SPI_1 
+#define SDCARD_SPI SPI1 
 
 // Indicate unit has RTC/Alarm
 #define HAS_RTC 1

--- a/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
+++ b/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
@@ -62,8 +62,8 @@ extern const uint8_t NUM_ANALOG_OUTPUTS;
 #define NUM_I2C 2
 
 // to use SPI_for_xmc_SD if desired by user
-#define XMC_SPI_for_xmc_SD XMC_SPI_1 
-#define SDCARD_SPI SPI1 
+#define XMC_SPI_for_xmc_SD XMC_SPI_1
+#define SDCARD_SPI SPI1
 
 // Indicate unit has RTC/Alarm
 #define HAS_RTC 1


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Solve the problem that the default spi is overwritten when the XMC4700 relax kit sets the SD card PIN to the default value.
Tested the default SPI pins and the SD card function, both work fine!

Related Issue
https://jirard.intra.infineon.com/browse/DESMAKERS-4316

Context
