### PR TITLE
Added spi

### DIFF
--- a/.github/workflows/commit_formatting.yml
+++ b/.github/workflows/commit_formatting.yml
@@ -1,0 +1,18 @@
+name: Commit message check
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: '100'
+    - uses: actions/setup-python@v5
+    - name: Check commit message formatting
+      run: source tools/ci.sh && ci_commit_formatting_run

--- a/cores/HardwareSerial.cpp
+++ b/cores/HardwareSerial.cpp
@@ -32,7 +32,7 @@ HardwareSerial::HardwareSerial(XMC_UART_t *xmc_uart_config,
                                RingBuffer *tx_buffer) {
     _XMC_UART_config = xmc_uart_config;
     _rx_buffer = rx_buffer;
-    _tx_buffer = tx_buffer;
+    _tx_buffer = tx_buffer; // TODO: replaced by TBUF (hardware register), can be actually removed
 }
 
 // Public Methods //////////////////////////////////////////////////////////////
@@ -119,10 +119,12 @@ int HardwareSerial::available(void) {
 }
 
 int HardwareSerial::availableForWrite(void) {
-    int tail = _tx_buffer->_iTail; // Snapshot index affected by irq
-    if (_tx_buffer->_iHead >= tail)
-        return SERIAL_BUFFER_SIZE - 1 - _tx_buffer->_iHead + tail;
-    return tail - _tx_buffer->_iHead - 1;
+    int available = XMC_USIC_CH_GetTransmitBufferStatus(_XMC_UART_config->channel);
+    if (available == XMC_USIC_CH_TBUF_STATUS_IDLE) {
+        return 0;
+    } else {
+        return 1;
+    } // TODO: should return bytes avaliable to write! need to enable txFIFO in the future
 }
 
 int HardwareSerial::peek(void) {
@@ -144,59 +146,19 @@ int HardwareSerial::read(void) {
 }
 
 void HardwareSerial::flush(void) {
-    while (_tx_buffer->_iHead != _tx_buffer->_iTail)
-        ; // wait for transmit data to be sent
-
     while (XMC_USIC_CH_GetTransmitBufferStatus(_XMC_UART_config->channel) ==
            XMC_USIC_CH_TBUF_STATUS_BUSY)
         ;
 }
 
 size_t HardwareSerial::write(const uint8_t uc_data) {
-// Is the hardware currently busy?
-#if defined(SERIAL_USE_U1C1)
-    if (_tx_buffer->_iTail != _tx_buffer->_iHead)
-#else
-    if ((XMC_USIC_CH_GetTransmitBufferStatus(_XMC_UART_config->channel) ==
-         XMC_USIC_CH_TBUF_STATUS_BUSY) ||
-        (_tx_buffer->_iTail != _tx_buffer->_iHead))
-#endif
-    {
-        // If busy we buffer
-        int nextWrite = _tx_buffer->_iHead + 1;
-        if (nextWrite >= SERIAL_BUFFER_SIZE)
-            nextWrite = 0;
+    // Is the hardware currently busy?
 
-        // This should always be false but in case transmission is completed before buffer, we need
-        // to reenable IRQ
-        if (XMC_USIC_CH_GetTransmitBufferStatus(_XMC_UART_config->channel) !=
-            XMC_USIC_CH_TBUF_STATUS_BUSY) {
-            XMC_UART_CH_EnableEvent(_XMC_UART_config->channel, XMC_UART_CH_EVENT_TRANSMIT_BUFFER);
-            XMC_UART_CH_Transmit(_XMC_UART_config->channel,
-                                 _tx_buffer->_aucBuffer[_tx_buffer->_iTail]);
-            _tx_buffer->_iTail++;
-            if (_tx_buffer->_iTail >= SERIAL_BUFFER_SIZE)
-                _tx_buffer->_iTail %= SERIAL_BUFFER_SIZE; // If iTail is larger than Serial Buffer
-                                                          // Size calculate the correct index value
-        }
+    // Make sure TX interrupt is enabled
+    XMC_UART_CH_EnableEvent(_XMC_UART_config->channel, XMC_UART_CH_EVENT_TRANSMIT_BUFFER);
+    // Bypass buffering and send character directly
+    XMC_UART_CH_Transmit(_XMC_UART_config->channel, uc_data);
 
-        unsigned long startTime = millis();
-        while (_tx_buffer->_iTail == nextWrite) {
-            if (millis() - startTime > 1000) {
-                return 0; // Spin locks if we're about to overwrite the buffer. This continues once
-                          // the data is
-                          // sent
-            }
-        }
-
-        _tx_buffer->_aucBuffer[_tx_buffer->_iHead] = uc_data;
-        _tx_buffer->_iHead = nextWrite;
-    } else {
-        // Make sure TX interrupt is enabled
-        XMC_UART_CH_EnableEvent(_XMC_UART_config->channel, XMC_UART_CH_EVENT_TRANSMIT_BUFFER);
-        // Bypass buffering and send character directly
-        XMC_UART_CH_Transmit(_XMC_UART_config->channel, uc_data);
-    }
     return 1;
 }
 
@@ -220,17 +182,8 @@ void HardwareSerial::IrqHandler(void) {
         XMC_UART_CH_ClearStatusFlag(_XMC_UART_config->channel,
                                     XMC_UART_CH_STATUS_FLAG_TRANSMIT_BUFFER_INDICATION);
 
-        if (_tx_buffer->_iTail != _tx_buffer->_iHead) {
-            XMC_UART_CH_Transmit(_XMC_UART_config->channel,
-                                 _tx_buffer->_aucBuffer[_tx_buffer->_iTail]);
-            _tx_buffer->_iTail++;
-            if (_tx_buffer->_iTail >= SERIAL_BUFFER_SIZE)
-                _tx_buffer->_iTail %= SERIAL_BUFFER_SIZE; // If iTail is larger than Serial Buffer
-                                                          // Size calculate the correct index value
-        } else {
-            // Mask off transmit interrupt so we don't get it any more
-            XMC_UART_CH_DisableEvent(_XMC_UART_config->channel, XMC_UART_CH_EVENT_TRANSMIT_BUFFER);
-        }
+        // Mask off transmit interrupt so we don't get it any more
+        XMC_UART_CH_DisableEvent(_XMC_UART_config->channel, XMC_UART_CH_EVENT_TRANSMIT_BUFFER);
     }
 }
 

--- a/iöjdk.fm
+++ b/iöjdk.fm
@@ -1,0 +1,17 @@
+  3.x-pre-release[m
+* [32madded_spi[m
+  core-test-xmc-3.x[m
+  master[m
+  [31mremotes/origin/3.x-pre-release[m
+  [31mremotes/origin/4.0.0-pre-release[m
+  [31mremotes/origin/DESMAKERS-4279-rename-the-metafile-vendor-from-infineon-to-infineon[m
+  [31mremotes/origin/DESMAKERS-4347-4350-development-instuctions-env-setup[m
+  [31mremotes/origin/DESMAKERS-4349-code_convention.md-in-xmc4arduino[m
+  [31mremotes/origin/HEAD[m -> origin/master
+  [31mremotes/origin/HIL-test[m
+  [31mremotes/origin/core-api-update[m
+  [31mremotes/origin/core-test-xmc-3.x[m
+  [31mremotes/origin/doc-preview[m
+  [31mremotes/origin/master[m
+  [31mremotes/origin/master-1.x[m
+  [31mremotes/origin/xmc-dev-ops[m

--- a/tests/Makefile.test
+++ b/tests/Makefile.test
@@ -32,3 +32,12 @@ DigitalIO
 # 1 boards
 
 make FQBN=arduino-git:xmc:XMC4700_Relax_Kit PORT=/dev/ttyACM1 UNITY_PATH=\Unity test_digitalio_single monitor
+
+## SPI
+
+# 2 boards
+make FQBN=arduino-git:xmc:XMC4700_Relax_Kit PORT=/dev/ttyACM0 test_spi_connected2_master monitor
+make FQBN=arduino-git:xmc:XMC4700_Relax_Kit PORT=/dev/ttyACM1 test_spi_connected2_slave monitor
+
+# 1 board, loopback
+make FQBN=arduino-git:xmc:XMC4700_Relax_Kit PORT=/dev/ttyACM0 test_spi_connected1_loopback monitor

--- a/tests/Makefile.test
+++ b/tests/Makefile.test
@@ -20,7 +20,7 @@ make FQBN=Infineon:xmc:XMC4700_Relax_Kit PORT=COM28 UNITY_PATH=\Unity test_wire_
 # 2 boards
 make FQBN=arduino-git:xmc:XMC4700_Relax_Kit PORT=/dev/ttyACM0 test_wire_connected2_masterpingpong monitor
 make FQBN=arduino-git:xmc:XMC4700_Relax_Kit PORT=/dev/ttyACM1 test_wire_connected2_slavepingpong monitor
-############branch1
+
 ## UART
 
 # 2 boards

--- a/tests/Makefile.test
+++ b/tests/Makefile.test
@@ -9,9 +9,8 @@
 make FQBN=Infineon:xmc:XMC1400_XMC2GO PORT=COM42 UNITY_PATH=\Unity test_can_single monitor
 
 # 2 boards
-make FQBN=Infineon:xmc:XMC1400_XMC2GO PORT=COM42 UNITY_PATH=\Unity test_can_connected2_node2 monitor
-make FQBN=Infineon:xmc:XMC1400_XMC2GO PORT=COM41 UNITY_PATH=\Unity test_can_connected2_node1 monitor
-
+make FQBN=arduino-git:xmc:XMC1400_XMC2GO PORT=COM42 UNITY_PATH=\Unity test_can_connected2_node2 monitor
+make FQBN=arduino-git:xmc:XMC1400_XMC2GO PORT=COM41 UNITY_PATH=\Unity test_can_connected2_node1 monitor
 
 ## IIC
 
@@ -19,11 +18,17 @@ make FQBN=Infineon:xmc:XMC1400_XMC2GO PORT=COM41 UNITY_PATH=\Unity test_can_conn
 make FQBN=Infineon:xmc:XMC4700_Relax_Kit PORT=COM28 UNITY_PATH=\Unity test_wire_connected1_pingpong monitor
 
 # 2 boards
-make FQBN=Infineon:xmc:XMC4700_Relax_Kit PORT=COM85 test_wire_connected2_masterpingpong monitor
-make FQBN=Infineon:xmc:XMC4700_Relax_Kit PORT=COM28 test_wire_connected2_slavepingpong monitor
+make FQBN=arduino-git:xmc:XMC4700_Relax_Kit PORT=/dev/ttyACM0 test_wire_connected2_masterpingpong monitor
+make FQBN=arduino-git:xmc:XMC4700_Relax_Kit PORT=/dev/ttyACM1 test_wire_connected2_slavepingpong monitor
 
 ## UART
 
 # 2 boards
-make FQBN=Infineon:xmc:XMC4700_Relax_Kit PORT=COM71 test_uart_connected2_tx monitor
-make FQBN=Infineon:xmc:XMC4700_Relax_Kit PORT=COM28 test_uart_connected2_rx monitor
+make FQBN=arduino-git:xmc:XMC4700_Relax_Kit PORT=/dev/ttyACM0 test_uart_connected2_tx monitor
+make FQBN=arduino-git:xmc:XMC4700_Relax_Kit PORT=/dev/ttyACM1 test_uart_connected2_rx monitor
+
+DigitalIO
+
+# 1 boards
+
+make FQBN=arduino-git:xmc:XMC4700_Relax_Kit PORT=/dev/ttyACM1 UNITY_PATH=\Unity test_digitalio_single monitor

--- a/tests/Makefile.test
+++ b/tests/Makefile.test
@@ -20,7 +20,7 @@ make FQBN=Infineon:xmc:XMC4700_Relax_Kit PORT=COM28 UNITY_PATH=\Unity test_wire_
 # 2 boards
 make FQBN=arduino-git:xmc:XMC4700_Relax_Kit PORT=/dev/ttyACM0 test_wire_connected2_masterpingpong monitor
 make FQBN=arduino-git:xmc:XMC4700_Relax_Kit PORT=/dev/ttyACM1 test_wire_connected2_slavepingpong monitor
-
+############branch1
 ## UART
 
 # 2 boards

--- a/tests/test_config.h
+++ b/tests/test_config.h
@@ -1,0 +1,19 @@
+/**
+ * @file test_config.h
+ * @brief Configuration file for board-specific test pin definitions.
+ *
+ * This header file contains the definitions of the pins used for testing
+ * purposes on the specific board. These pins are configured as output and 
+ * input pins for various test scenarios.
+ *
+ */
+ #ifndef TEST_CONFIG_H
+ #define TEST_CONFIG_H
+ 
+ #include <stdint.h>
+ 
+ // test defines
+ const uint8_t TEST_DIGITALIO_OUTPUT = 4;  // IO0
+ const uint8_t TEST_DIGITALIO_INPUT = 2;   // IO1
+ 
+ #endif // TEST_CONFIG_H


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
The submodule "Arduino-Core-Test" in the repo "XMC-for-Arduino" linked to an older version. The version of "Arduino-Core-Test" was updated to the newest one, the different tests were executed and it was documented which tests are also working. The files where adapted accordingly.


Related Issue
It's not an issue, but tasks that still need to be done:
1. Interrupts: It exists an open ticket for the interrupt-problem. A sending interrupt is not received by an receiving pin. The existing test shows that 4/6 tests don't pass, which CAN be traced back to this. Therefore, the interrupt-functionality needs to be solved first. BUG-Ticket needs to be created!
2. Timing: the following test function is not passed: RUN_TEST_CASE(time_single_internal, testDelayMicroseconds)
--> Expected Delay: 500000 microseconds; Actual Delay: 506483 microseconds; Tolerance: 100 microseconds (result: values not within delta 100)
3. IIC is not working for 1 board only: make FQBN=Infineon:xmc:XMC4700_Relax_Kit PORT=COM28 UNITY_PATH=\Unity test_wire_connected1_pingpong monitor --> There is an open ToDo

Context
-