### PR TITLE
variants/XMC1400: Add SPI pin definitions.

### DIFF
--- a/variants/XMC1400/config/XMC1400_Arduino_Kit/pins_arduino.h
+++ b/variants/XMC1400/config/XMC1400_Arduino_Kit/pins_arduino.h
@@ -79,6 +79,11 @@ extern const uint8_t NUM_ANALOG_INPUTS;
 #define PIN_SPI_MISO 12
 #define PIN_SPI_SCK 13
 
+extern uint8_t SS;
+extern uint8_t MOSI;
+extern uint8_t MISO;
+extern uint8_t SCK;
+
 #define A0 0
 #define A1 1
 #define A2 2

--- a/variants/XMC1400/config/XMC1400_XMC2GO/pins_arduino.h
+++ b/variants/XMC1400/config/XMC1400_XMC2GO/pins_arduino.h
@@ -85,6 +85,11 @@ extern const uint8_t NUM_ANALOG_INPUTS;
 #define PIN_SPI_MISO 0
 #define PIN_SPI_SCK 2
 
+extern uint8_t SS;
+extern uint8_t MOSI;
+extern uint8_t MISO;
+extern uint8_t SCK;
+
 // Define analog pin
 #define A0 0
 #define A1 1


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

**Description**
This pull request includes changes to the `pins_arduino.h` files for the `XMC1400_Arduino_Kit` and `XMC1400_XMC2GO` variants. The changes involve adding external variable declarations for SPI pin assignments.

* [`variants/XMC1400/config/XMC1400_Arduino_Kit/pins_arduino.h`](diffhunk://#diff-aa5e6a88ffc2c6c8bbacf26f182bf2d03e43768b38784badfe5d10aa6bd265d5R82-R86): Added external variable declarations for `SS`, `MOSI`, `MISO`, and `SCK` to define SPI pin assignments.
* [`variants/XMC1400/config/XMC1400_XMC2GO/pins_arduino.h`](diffhunk://#diff-79a05e1364466776ab57153e2bc5b27e802bf3e3f7417e5df29bb29d10dd7217R88-R92): Added external variable declarations for `SS`, `MOSI`, `MISO`, and `SCK` to define SPI pin assignments.

**Related Issue**
MHB and other libs using SPI not compiling on XMC1400-based boards.