### PR TITLE
Core api update iic modify

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -244,7 +244,7 @@ uint8_t TwoWire::endTransmission(bool sendStop) {
             if(hasError || (millis() - start > timeout)) {
                 resetBus();
                 flush();
-                return 4; // NACK received
+                return 5; // NACK received
             }
         } while (!(StatusFlag & XMC_I2C_CH_STATUS_FLAG_ACK_RECEIVED));
 
@@ -262,7 +262,7 @@ uint8_t TwoWire::endTransmission(bool sendStop) {
         while (XMC_USIC_CH_GetTransmitBufferStatus(XMC_I2C_config->channel) ==XMC_USIC_CH_TBUF_STATUS_BUSY) {
             if (this->hasError == true || (millis() - start > timeout)) {
                 flush();
-                return 4;
+                return 5;
             }
         }
         inRepStart = false;

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -209,10 +209,6 @@ size_t  TwoWire::requestFrom(uint8_t address, size_t quantity, bool sendStop) {
     return rx_ringBuffer.available();
 }
 
-// size_t  TwoWire::requestFrom(uint8_t address, size_t quantity, bool sendStop) {
-//     return requestFrom((uint8_t)address, quantity, (uint32_t)0, (uint8_t)0,sendStop);
-// }
-
 size_t  TwoWire::requestFrom(uint8_t address, size_t quantity) {
     return requestFrom((uint8_t)address, quantity, true);
 }

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -23,50 +23,70 @@ TwoWire::TwoWire(XMC_I2C_t *conf) {
 
 void TwoWire::begin(void) {
     // To-Do for future work need to check
-    // Check if desire USIC channel is already in use 
-    // if ((XMC_I2C_config->channel->CCR & USIC_CH_CCR_MODE_Msk) == XMC_USIC_CH_OPERATING_MODE_SPI) {
+    // Check if desire USIC channel is already in use
+    // if ((XMC_I2C_config->channel->CCR & USIC_CH_CCR_MODE_Msk) == XMC_USIC_CH_OPERATING_MODE_SPI)
+    // {
     //     SPI.end();
     // }
     hasError = false;
     isMaster = true;
 
     XMC_I2C_CH_Init(XMC_I2C_config->channel, &(XMC_I2C_config->channel_config));
-    XMC_USIC_CH_SetInputSource(XMC_I2C_config->channel, XMC_USIC_CH_INPUT_DX0, XMC_I2C_config->input_source_dx0);
-    XMC_USIC_CH_SetInputSource(XMC_I2C_config->channel, XMC_USIC_CH_INPUT_DX1, XMC_I2C_config->input_source_dx1);
+    XMC_USIC_CH_SetInputSource(XMC_I2C_config->channel, XMC_USIC_CH_INPUT_DX0,
+                               XMC_I2C_config->input_source_dx0);
+    XMC_USIC_CH_SetInputSource(XMC_I2C_config->channel, XMC_USIC_CH_INPUT_DX1,
+                               XMC_I2C_config->input_source_dx1);
     /* configure i2c tx fifo */
-    XMC_USIC_CH_TXFIFO_Configure(XMC_I2C_config->channel, 16, XMC_USIC_CH_FIFO_SIZE_16WORDS,(uint32_t)15);
+    XMC_USIC_CH_TXFIFO_Configure(XMC_I2C_config->channel, 16, XMC_USIC_CH_FIFO_SIZE_16WORDS,
+                                 (uint32_t)15);
     /* configure i2c rx fifo */
-    XMC_USIC_CH_RXFIFO_Configure(XMC_I2C_config->channel, 0, XMC_USIC_CH_FIFO_SIZE_16WORDS,(uint32_t)(15));
+    XMC_USIC_CH_RXFIFO_Configure(XMC_I2C_config->channel, 0, XMC_USIC_CH_FIFO_SIZE_16WORDS,
+                                 (uint32_t)(15));
 
-    XMC_USIC_CH_SetInterruptNodePointer(XMC_I2C_config->channel, XMC_USIC_CH_INTERRUPT_NODE_POINTER_PROTOCOL,XMC_I2C_config->protocol_irq_service_request);
+    XMC_USIC_CH_SetInterruptNodePointer(XMC_I2C_config->channel,
+                                        XMC_USIC_CH_INTERRUPT_NODE_POINTER_PROTOCOL,
+                                        XMC_I2C_config->protocol_irq_service_request);
 
     NVIC_SetPriority((IRQn_Type)XMC_I2C_config->protocol_irq_num, 3U);
     NVIC_EnableIRQ((IRQn_Type)XMC_I2C_config->protocol_irq_num);
 
-    XMC_I2C_CH_EnableEvent(XMC_I2C_config->channel,(uint32_t)(XMC_I2C_CH_EVENT_NACK | XMC_I2C_CH_EVENT_DATA_LOST |XMC_I2C_CH_EVENT_ARBITRATION_LOST | XMC_I2C_CH_EVENT_ERROR));
+    XMC_I2C_CH_EnableEvent(XMC_I2C_config->channel,
+                           (uint32_t)(XMC_I2C_CH_EVENT_NACK | XMC_I2C_CH_EVENT_DATA_LOST |
+                                      XMC_I2C_CH_EVENT_ARBITRATION_LOST | XMC_I2C_CH_EVENT_ERROR));
 
     XMC_I2C_CH_Start(XMC_I2C_config->channel);
 
-    XMC_GPIO_Init((XMC_GPIO_PORT_t *)XMC_I2C_config->sda.port, (uint8_t)XMC_I2C_config->sda.pin, &(XMC_I2C_config->sda_config));
-    XMC_GPIO_Init((XMC_GPIO_PORT_t *)XMC_I2C_config->scl.port, (uint8_t)XMC_I2C_config->scl.pin, &(XMC_I2C_config->scl_config));
+    XMC_GPIO_Init((XMC_GPIO_PORT_t *)XMC_I2C_config->sda.port, (uint8_t)XMC_I2C_config->sda.pin,
+                  &(XMC_I2C_config->sda_config));
+    XMC_GPIO_Init((XMC_GPIO_PORT_t *)XMC_I2C_config->scl.port, (uint8_t)XMC_I2C_config->scl.pin,
+                  &(XMC_I2C_config->scl_config));
 }
 
 void TwoWire::begin(uint8_t address) {
-    //To-Do for future work need to check
-    // Check if desire USIC channel is already in use
-    // if ((XMC_I2C_config->channel->CCR & USIC_CH_CCR_MODE_Msk) == XMC_USIC_CH_OPERATING_MODE_SPI) {
-    //     SPI.end();
-    // }
+    // To-Do for future work need to check
+    //  Check if desire USIC channel is already in use
+    //  if ((XMC_I2C_config->channel->CCR & USIC_CH_CCR_MODE_Msk) == XMC_USIC_CH_OPERATING_MODE_SPI)
+    //  {
+    //      SPI.end();
+    //  }
     isMaster = false;
     slaveAddress = address;
 
     XMC_I2C_CH_Init(XMC_I2C_config->channel, &(XMC_I2C_config->channel_config));
-    XMC_USIC_CH_SetInputSource(XMC_I2C_config->channel, XMC_USIC_CH_INPUT_DX0, XMC_I2C_config->input_source_dx0);
-    XMC_USIC_CH_SetInputSource(XMC_I2C_config->channel, XMC_USIC_CH_INPUT_DX1, XMC_I2C_config->input_source_dx1);
+    XMC_USIC_CH_SetInputSource(XMC_I2C_config->channel, XMC_USIC_CH_INPUT_DX0,
+                               XMC_I2C_config->input_source_dx0);
+    XMC_USIC_CH_SetInputSource(XMC_I2C_config->channel, XMC_USIC_CH_INPUT_DX1,
+                               XMC_I2C_config->input_source_dx1);
 
-    XMC_USIC_CH_SetInterruptNodePointer(XMC_I2C_config->channel,XMC_USIC_CH_INTERRUPT_NODE_POINTER_RECEIVE,XMC_I2C_config->slave_receive_irq_service_request);
-    XMC_USIC_CH_SetInterruptNodePointer(XMC_I2C_config->channel,XMC_USIC_CH_INTERRUPT_NODE_POINTER_ALTERNATE_RECEIVE,XMC_I2C_config->slave_receive_irq_service_request);
-    XMC_USIC_CH_SetInterruptNodePointer(XMC_I2C_config->channel,XMC_USIC_CH_INTERRUPT_NODE_POINTER_PROTOCOL,XMC_I2C_config->protocol_irq_service_request);
+    XMC_USIC_CH_SetInterruptNodePointer(XMC_I2C_config->channel,
+                                        XMC_USIC_CH_INTERRUPT_NODE_POINTER_RECEIVE,
+                                        XMC_I2C_config->slave_receive_irq_service_request);
+    XMC_USIC_CH_SetInterruptNodePointer(XMC_I2C_config->channel,
+                                        XMC_USIC_CH_INTERRUPT_NODE_POINTER_ALTERNATE_RECEIVE,
+                                        XMC_I2C_config->slave_receive_irq_service_request);
+    XMC_USIC_CH_SetInterruptNodePointer(XMC_I2C_config->channel,
+                                        XMC_USIC_CH_INTERRUPT_NODE_POINTER_PROTOCOL,
+                                        XMC_I2C_config->protocol_irq_service_request);
 
     NVIC_SetPriority((IRQn_Type)XMC_I2C_config->slave_receive_irq_num, 3U);
     NVIC_EnableIRQ((IRQn_Type)XMC_I2C_config->slave_receive_irq_num);
@@ -78,14 +98,22 @@ void TwoWire::begin(uint8_t address) {
     (void)XMC_I2C_CH_GetReceivedData(XMC_I2C_config->channel);
     (void)XMC_I2C_CH_GetReceivedData(XMC_I2C_config->channel);
 
-    XMC_I2C_CH_EnableEvent(XMC_I2C_config->channel,(uint32_t)(XMC_I2C_CH_EVENT_DATA_LOST |XMC_I2C_CH_EVENT_ARBITRATION_LOST | XMC_I2C_CH_EVENT_ERROR));
-    XMC_I2C_CH_EnableEvent(XMC_I2C_config->channel,(uint32_t)((uint32_t)XMC_I2C_CH_EVENT_STANDARD_RECEIVE |(uint32_t)XMC_I2C_CH_EVENT_ALTERNATIVE_RECEIVE));
-    XMC_I2C_CH_EnableEvent(XMC_I2C_config->channel,(uint32_t)((uint32_t)XMC_I2C_CH_EVENT_SLAVE_READ_REQUEST |(uint32_t)XMC_I2C_CH_EVENT_STOP_CONDITION_RECEIVED));
+    XMC_I2C_CH_EnableEvent(XMC_I2C_config->channel,
+                           (uint32_t)(XMC_I2C_CH_EVENT_DATA_LOST |
+                                      XMC_I2C_CH_EVENT_ARBITRATION_LOST | XMC_I2C_CH_EVENT_ERROR));
+    XMC_I2C_CH_EnableEvent(XMC_I2C_config->channel,
+                           (uint32_t)((uint32_t)XMC_I2C_CH_EVENT_STANDARD_RECEIVE |
+                                      (uint32_t)XMC_I2C_CH_EVENT_ALTERNATIVE_RECEIVE));
+    XMC_I2C_CH_EnableEvent(XMC_I2C_config->channel,
+                           (uint32_t)((uint32_t)XMC_I2C_CH_EVENT_SLAVE_READ_REQUEST |
+                                      (uint32_t)XMC_I2C_CH_EVENT_STOP_CONDITION_RECEIVED));
 
     XMC_I2C_CH_Start(XMC_I2C_config->channel);
 
-    XMC_GPIO_Init((XMC_GPIO_PORT_t *)XMC_I2C_config->sda.port, (uint8_t)XMC_I2C_config->sda.pin, &(XMC_I2C_config->sda_config));
-    XMC_GPIO_Init((XMC_GPIO_PORT_t *)XMC_I2C_config->scl.port, (uint8_t)XMC_I2C_config->scl.pin, &(XMC_I2C_config->scl_config));
+    XMC_GPIO_Init((XMC_GPIO_PORT_t *)XMC_I2C_config->sda.port, (uint8_t)XMC_I2C_config->sda.pin,
+                  &(XMC_I2C_config->sda_config));
+    XMC_GPIO_Init((XMC_GPIO_PORT_t *)XMC_I2C_config->scl.port, (uint8_t)XMC_I2C_config->scl.pin,
+                  &(XMC_I2C_config->scl_config));
 }
 
 void TwoWire::end(void) {
@@ -96,30 +124,37 @@ void TwoWire::end(void) {
         XMC_USIC_CH_SetInputSource(XMC_I2C_config->channel, XMC_USIC_CH_INPUT_DX1, XMC_INPUT_A);
 
         NVIC_DisableIRQ((IRQn_Type)XMC_I2C_config->protocol_irq_num);
-        XMC_I2C_CH_DisableEvent(XMC_I2C_config->channel,(uint32_t)(XMC_I2C_CH_EVENT_NACK | XMC_I2C_CH_EVENT_DATA_LOST |XMC_I2C_CH_EVENT_ARBITRATION_LOST |XMC_I2C_CH_EVENT_ERROR));
+        XMC_I2C_CH_DisableEvent(XMC_I2C_config->channel,
+                                (uint32_t)(XMC_I2C_CH_EVENT_NACK | XMC_I2C_CH_EVENT_DATA_LOST |
+                                           XMC_I2C_CH_EVENT_ARBITRATION_LOST |
+                                           XMC_I2C_CH_EVENT_ERROR));
 
         if (isMaster == false) {
-            XMC_I2C_CH_DisableEvent(XMC_I2C_config->channel,(uint32_t)((uint32_t)XMC_I2C_CH_EVENT_SLAVE_READ_REQUEST |(uint32_t)XMC_I2C_CH_EVENT_STOP_CONDITION_RECEIVED));
+            XMC_I2C_CH_DisableEvent(XMC_I2C_config->channel,
+                                    (uint32_t)((uint32_t)XMC_I2C_CH_EVENT_SLAVE_READ_REQUEST |
+                                               (uint32_t)XMC_I2C_CH_EVENT_STOP_CONDITION_RECEIVED));
             NVIC_DisableIRQ((IRQn_Type)XMC_I2C_config->slave_receive_irq_num);
-            XMC_I2C_CH_DisableEvent(XMC_I2C_config->channel,(uint32_t)((uint32_t)XMC_I2C_CH_EVENT_STANDARD_RECEIVE |(uint32_t)XMC_I2C_CH_EVENT_ALTERNATIVE_RECEIVE));
+            XMC_I2C_CH_DisableEvent(XMC_I2C_config->channel,
+                                    (uint32_t)((uint32_t)XMC_I2C_CH_EVENT_STANDARD_RECEIVE |
+                                               (uint32_t)XMC_I2C_CH_EVENT_ALTERNATIVE_RECEIVE));
         }
 
         flush();
         /* Disable i2c tx fifo */
-        XMC_USIC_CH_TXFIFO_Configure(XMC_I2C_config->channel, 16, XMC_USIC_CH_FIFO_DISABLED,(uint32_t)15);
+        XMC_USIC_CH_TXFIFO_Configure(XMC_I2C_config->channel, 16, XMC_USIC_CH_FIFO_DISABLED,
+                                     (uint32_t)15);
 
         /* Disable i2c rx fifo */
-        XMC_USIC_CH_RXFIFO_Configure(XMC_I2C_config->channel, 0, XMC_USIC_CH_FIFO_DISABLED,(uint32_t)(15));
+        XMC_USIC_CH_RXFIFO_Configure(XMC_I2C_config->channel, 0, XMC_USIC_CH_FIFO_DISABLED,
+                                     (uint32_t)(15));
     }
 }
 
-void TwoWire::setClock(uint32_t clock) { 
-    XMC_I2C_CH_SetBaudrate(XMC_I2C_config->channel, clock); 
-}
+void TwoWire::setClock(uint32_t clock) { XMC_I2C_CH_SetBaudrate(XMC_I2C_config->channel, clock); }
 
-size_t  TwoWire::requestFrom(uint8_t address, size_t quantity, bool sendStop) {
-    if(quantity == 0) {
-        if(sendStop) {
+size_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool sendStop) {
+    if (quantity == 0) {
+        if (sendStop) {
             XMC_I2C_CH_MasterStop(XMC_I2C_config->channel);
         }
         return 0;
@@ -127,67 +162,75 @@ size_t  TwoWire::requestFrom(uint8_t address, size_t quantity, bool sendStop) {
     if (quantity > BUFFER_LENGTH) {
         quantity = BUFFER_LENGTH;
     }
-    
+
     rx_ringBuffer.clear();
     if (inRepStart) {
-        XMC_I2C_CH_MasterRepeatedStart(XMC_I2C_config->channel, (txAddress << 1), XMC_I2C_CH_CMD_READ);
+        XMC_I2C_CH_MasterRepeatedStart(XMC_I2C_config->channel, (txAddress << 1),
+                                       XMC_I2C_CH_CMD_READ);
         inRepStart = false;
     } else {
         XMC_I2C_CH_MasterStart(XMC_I2C_config->channel, (txAddress << 1), XMC_I2C_CH_CMD_READ);
     }
 
     uint32_t start = millis();
-    while (!(XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel) & XMC_I2C_CH_STATUS_FLAG_ACK_RECEIVED)) {
+    while (!(XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel) &
+             XMC_I2C_CH_STATUS_FLAG_ACK_RECEIVED)) {
         if (millis() - start > timeout || hasError) {
             flush();
             return 0;
         }
     }
 
-    for (uint8_t count = 0; count < (quantity-1); count++) {
-                XMC_I2C_CH_MasterReceiveAck(XMC_I2C_config->channel);
+    for (uint8_t count = 0; count < (quantity - 1); count++) {
+        XMC_I2C_CH_MasterReceiveAck(XMC_I2C_config->channel);
 
         start = millis();
         // Wait for Receive, leave when NACK is detected
-       while (!(XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel) & (XMC_I2C_CH_STATUS_FLAG_RECEIVE_INDICATION |XMC_I2C_CH_STATUS_FLAG_ALTERNATIVE_RECEIVE_INDICATION)))
-       {
-        if(millis() - start > timeout || hasError){
+        while (!(XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel) &
+                 (XMC_I2C_CH_STATUS_FLAG_RECEIVE_INDICATION |
+                  XMC_I2C_CH_STATUS_FLAG_ALTERNATIVE_RECEIVE_INDICATION))) {
+            if (millis() - start > timeout || hasError) {
+                flush();
+                return count;
+            }
+        }
+        XMC_I2C_CH_ClearStatusFlag(XMC_I2C_config->channel,
+                                   XMC_I2C_CH_STATUS_FLAG_RECEIVE_INDICATION |
+                                       XMC_I2C_CH_STATUS_FLAG_ALTERNATIVE_RECEIVE_INDICATION);
+        uint8_t data = XMC_I2C_CH_GetReceivedData(XMC_I2C_config->channel);
+        if (rx_ringBuffer.isFull()) {
             flush();
             return count;
         }
-       }
-        XMC_I2C_CH_ClearStatusFlag(XMC_I2C_config->channel,XMC_I2C_CH_STATUS_FLAG_RECEIVE_INDICATION |XMC_I2C_CH_STATUS_FLAG_ALTERNATIVE_RECEIVE_INDICATION);
-       uint8_t data =  XMC_I2C_CH_GetReceivedData(XMC_I2C_config->channel);
-       if(rx_ringBuffer.isFull()){
-        flush();
-        return count;
-       }
-       rx_ringBuffer.store_char(data);
-
+        rx_ringBuffer.store_char(data);
     }
     XMC_I2C_CH_MasterReceiveNack(XMC_I2C_config->channel);
 
-        start = millis();
-        // Wait for Receive, leave when NACK is detected
-       while (!(XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel) & (XMC_I2C_CH_STATUS_FLAG_RECEIVE_INDICATION |XMC_I2C_CH_STATUS_FLAG_ALTERNATIVE_RECEIVE_INDICATION)))
-       {
-        if(millis() - start > timeout || hasError){
+    start = millis();
+    // Wait for Receive, leave when NACK is detected
+    while (!(XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel) &
+             (XMC_I2C_CH_STATUS_FLAG_RECEIVE_INDICATION |
+              XMC_I2C_CH_STATUS_FLAG_ALTERNATIVE_RECEIVE_INDICATION))) {
+        if (millis() - start > timeout || hasError) {
             flush();
             return quantity - 1;
         }
-       }
-        XMC_I2C_CH_ClearStatusFlag(XMC_I2C_config->channel,XMC_I2C_CH_STATUS_FLAG_RECEIVE_INDICATION |XMC_I2C_CH_STATUS_FLAG_ALTERNATIVE_RECEIVE_INDICATION);
-       uint8_t data =  XMC_I2C_CH_GetReceivedData(XMC_I2C_config->channel);
-       if(rx_ringBuffer.isFull()){
+    }
+    XMC_I2C_CH_ClearStatusFlag(XMC_I2C_config->channel,
+                               XMC_I2C_CH_STATUS_FLAG_RECEIVE_INDICATION |
+                                   XMC_I2C_CH_STATUS_FLAG_ALTERNATIVE_RECEIVE_INDICATION);
+    uint8_t data = XMC_I2C_CH_GetReceivedData(XMC_I2C_config->channel);
+    if (rx_ringBuffer.isFull()) {
         flush();
-        return quantity-1;
-       }
-       rx_ringBuffer.store_char(data);
+        return quantity - 1;
+    }
+    rx_ringBuffer.store_char(data);
 
     if (sendStop) {
         XMC_I2C_CH_MasterStop(XMC_I2C_config->channel);
         start = millis();
-        while (XMC_USIC_CH_GetTransmitBufferStatus(XMC_I2C_config->channel) ==XMC_USIC_CH_TBUF_STATUS_BUSY) {
+        while (XMC_USIC_CH_GetTransmitBufferStatus(XMC_I2C_config->channel) ==
+               XMC_USIC_CH_TBUF_STATUS_BUSY) {
             if (this->hasError == true || (millis() - start > timeout)) {
                 inRepStart = false;
                 flush();
@@ -199,7 +242,7 @@ size_t  TwoWire::requestFrom(uint8_t address, size_t quantity, bool sendStop) {
     return rx_ringBuffer.available();
 }
 
-size_t  TwoWire::requestFrom(uint8_t address, size_t quantity) {
+size_t TwoWire::requestFrom(uint8_t address, size_t quantity) {
     return requestFrom((uint8_t)address, quantity, true);
 }
 
@@ -224,7 +267,7 @@ void TwoWire::beginTransmission(uint8_t address) {
 uint8_t TwoWire::endTransmission(bool sendStop) {
     uint32_t StatusFlag;
     XMC_I2C_CH_MasterStart(XMC_I2C_config->channel, (txAddress << 1), XMC_I2C_CH_CMD_WRITE);
-    while(tx_ringBuffer.available() >0) {
+    while (tx_ringBuffer.available() > 0) {
         uint8_t data = tx_ringBuffer.read_char();
         XMC_I2C_CH_MasterTransmit(XMC_I2C_config->channel, data);
         uint32_t start = millis();
@@ -232,13 +275,13 @@ uint8_t TwoWire::endTransmission(bool sendStop) {
         do {
             StatusFlag = XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel);
             // Check for NACK, indicates that no slave with desired address is on the bus
-            if(hasError || (millis() - start > timeout)) {
+            if (hasError || (millis() - start > timeout)) {
                 flush();
                 return 5; // NACK received
             }
         } while (!(StatusFlag & XMC_I2C_CH_STATUS_FLAG_ACK_RECEIVED));
 
-        if(StatusFlag & XMC_I2C_CH_STATUS_FLAG_NACK_RECEIVED) {
+        if (StatusFlag & XMC_I2C_CH_STATUS_FLAG_NACK_RECEIVED) {
             // NACK received, slave is not present
             flush();
             return 2; // NACK received
@@ -249,7 +292,8 @@ uint8_t TwoWire::endTransmission(bool sendStop) {
     if (sendStop) {
         XMC_I2C_CH_MasterStop(XMC_I2C_config->channel);
         uint32_t start = millis();
-        while (XMC_USIC_CH_GetTransmitBufferStatus(XMC_I2C_config->channel) ==XMC_USIC_CH_TBUF_STATUS_BUSY) {
+        while (XMC_USIC_CH_GetTransmitBufferStatus(XMC_I2C_config->channel) ==
+               XMC_USIC_CH_TBUF_STATUS_BUSY) {
             if (this->hasError == true || (millis() - start > timeout)) {
                 flush();
                 return 5;
@@ -264,9 +308,7 @@ uint8_t TwoWire::endTransmission(bool sendStop) {
     return 0;
 }
 
-uint8_t TwoWire::endTransmission(void) { 
-    return endTransmission(true); 
-}
+uint8_t TwoWire::endTransmission(void) { return endTransmission(true); }
 
 size_t TwoWire::write(uint8_t data) {
     if (transmitting) {
@@ -275,24 +317,25 @@ size_t TwoWire::write(uint8_t data) {
         }
         tx_ringBuffer.store_char(data);
         return 1;
-    } 
-        // in slave send mode
-        // reply to master
-        if ((XMC_I2C_config->channel->CCR & USIC_CH_CCR_MODE_Msk) !=XMC_USIC_CH_OPERATING_MODE_I2C) {
-            if (isMaster) {
-                Wire.begin();
-            } else {
-                Wire.begin(slaveAddress);
-            }
+    }
+    // in slave send mode
+    // reply to master
+    if ((XMC_I2C_config->channel->CCR & USIC_CH_CCR_MODE_Msk) != XMC_USIC_CH_OPERATING_MODE_I2C) {
+        if (isMaster) {
+            Wire.begin();
+        } else {
+            Wire.begin(slaveAddress);
         }
-        XMC_I2C_CH_SlaveTransmit(XMC_I2C_config->channel, data);
-        uint32_t start = millis();
-        while (XMC_USIC_CH_GetTransmitBufferStatus(XMC_I2C_config->channel) ==XMC_USIC_CH_TBUF_STATUS_BUSY) {
-            if (this->hasError == true || (millis() - start > timeout)) {
-                flush();
-                return 0;
-            }
+    }
+    XMC_I2C_CH_SlaveTransmit(XMC_I2C_config->channel, data);
+    uint32_t start = millis();
+    while (XMC_USIC_CH_GetTransmitBufferStatus(XMC_I2C_config->channel) ==
+           XMC_USIC_CH_TBUF_STATUS_BUSY) {
+        if (this->hasError == true || (millis() - start > timeout)) {
+            flush();
+            return 0;
         }
+    }
     return 1;
 }
 
@@ -300,48 +343,47 @@ size_t TwoWire::write(const uint8_t *data, size_t quantity) {
     if (transmitting) {
         size_t written = 0;
         for (size_t i = 0; i < quantity; ++i) {
-            if(!write(data[i])) {
+            if (!write(data[i])) {
                 break;
             }
             written++;
         }
         return written;
-    } 
-        // in slave send mode
-        // reply to master
-        if ((XMC_I2C_config->channel->CCR & USIC_CH_CCR_MODE_Msk) !=XMC_USIC_CH_OPERATING_MODE_I2C) {
-            if (isMaster) {
-                Wire.begin();
-            } else {
-                Wire.begin(slaveAddress);
-            }
-        }
-        for (uint8_t c = 0; c < quantity; c++) {
-            XMC_I2C_CH_SlaveTransmit(XMC_I2C_config->channel, data[c]);
-        }
-        uint32_t start = millis();
-        while (XMC_USIC_CH_GetTransmitBufferStatus(XMC_I2C_config->channel) == XMC_USIC_CH_TBUF_STATUS_BUSY) {
-            if (this->hasError == true || (millis() - start > timeout)) {
-                flush();
-                return 0;
-            }
-        }
-    return quantity;
     }
-
-int TwoWire::available(void) { 
-    return rx_ringBuffer.available(); 
+    // in slave send mode
+    // reply to master
+    if ((XMC_I2C_config->channel->CCR & USIC_CH_CCR_MODE_Msk) != XMC_USIC_CH_OPERATING_MODE_I2C) {
+        if (isMaster) {
+            Wire.begin();
+        } else {
+            Wire.begin(slaveAddress);
+        }
+    }
+    for (uint8_t c = 0; c < quantity; c++) {
+        XMC_I2C_CH_SlaveTransmit(XMC_I2C_config->channel, data[c]);
+    }
+    uint32_t start = millis();
+    while (XMC_USIC_CH_GetTransmitBufferStatus(XMC_I2C_config->channel) ==
+           XMC_USIC_CH_TBUF_STATUS_BUSY) {
+        if (this->hasError == true || (millis() - start > timeout)) {
+            flush();
+            return 0;
+        }
+    }
+    return quantity;
 }
 
+int TwoWire::available(void) { return rx_ringBuffer.available(); }
+
 int TwoWire::read(void) {
-    if(rx_ringBuffer.available() == 0){
-       return -1;
+    if (rx_ringBuffer.available() == 0) {
+        return -1;
     }
     return rx_ringBuffer.read_char();
 }
 
 int TwoWire::peek(void) {
-    if(rx_ringBuffer.available() == 0){
+    if (rx_ringBuffer.available() == 0) {
         return -1;
     }
     return rx_ringBuffer.peek();
@@ -352,7 +394,8 @@ void TwoWire::flush(void) {
     if (isMaster) {
         XMC_USIC_CH_TXFIFO_Flush(XMC_I2C_config->channel);
         XMC_USIC_CH_RXFIFO_Flush(XMC_I2C_config->channel);
-        XMC_USIC_CH_SetTransmitBufferStatus(XMC_I2C_config->channel, XMC_USIC_CH_TBUF_STATUS_SET_IDLE);
+        XMC_USIC_CH_SetTransmitBufferStatus(XMC_I2C_config->channel,
+                                            XMC_USIC_CH_TBUF_STATUS_SET_IDLE);
     } else {
         /*Flush receive buffer*/
         (void)XMC_I2C_CH_GetReceivedData(XMC_I2C_config->channel);
@@ -368,21 +411,21 @@ void TwoWire::flush(void) {
 }
 
 void TwoWire::ReceiveHandler(void) {
-    uint32_t data =XMC_I2C_CH_GetReceivedData(XMC_I2C_config->channel);
+    uint32_t data = XMC_I2C_CH_GetReceivedData(XMC_I2C_config->channel);
     noInterrupts();
-   if(pre_rx_ringBuffer.isFull()) {
-    hasError = true;
+    if (pre_rx_ringBuffer.isFull()) {
+        hasError = true;
     } else {
         pre_rx_ringBuffer.store_char(data);
     }
     interrupts();
-
 }
 
 void TwoWire::ProtocolHandler(void) {
     uint32_t flag_status = XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel);
     if (isMaster) {
-        if (flag_status &(uint32_t)(XMC_I2C_CH_STATUS_FLAG_NACK_RECEIVED |
+        if (flag_status &
+            (uint32_t)(XMC_I2C_CH_STATUS_FLAG_NACK_RECEIVED |
                        XMC_I2C_CH_STATUS_FLAG_ARBITRATION_LOST | XMC_I2C_CH_STATUS_FLAG_ERROR |
                        XMC_I2C_CH_STATUS_FLAG_DATA_LOST_INDICATION)) {
             XMC_I2C_CH_ClearStatusFlag(
@@ -400,22 +443,25 @@ void TwoWire::ProtocolHandler(void) {
                                         XMC_I2C_CH_STATUS_FLAG_ERROR |
                                         XMC_I2C_CH_STATUS_FLAG_DATA_LOST_INDICATION));
             hasError = true;
-    } if (flag_status & (uint32_t)XMC_I2C_CH_STATUS_FLAG_SLAVE_READ_REQUESTED) {
-            XMC_I2C_CH_ClearStatusFlag(XMC_I2C_config->channel,XMC_I2C_CH_STATUS_FLAG_SLAVE_READ_REQUESTED);
+        }
+        if (flag_status & (uint32_t)XMC_I2C_CH_STATUS_FLAG_SLAVE_READ_REQUESTED) {
+            XMC_I2C_CH_ClearStatusFlag(XMC_I2C_config->channel,
+                                       XMC_I2C_CH_STATUS_FLAG_SLAVE_READ_REQUESTED);
 
-           noInterrupts();
-           while(pre_rx_ringBuffer.available()) {
-            rx_ringBuffer.store_char(pre_rx_ringBuffer.read_char());
-           }
-           interrupts();
-              OnReceiveService(rx_ringBuffer.available());
+            noInterrupts();
+            while (pre_rx_ringBuffer.available()) {
+                rx_ringBuffer.store_char(pre_rx_ringBuffer.read_char());
+            }
+            interrupts();
+            OnReceiveService(rx_ringBuffer.available());
             OnRequestService();
-    }  if (flag_status & (uint32_t)XMC_I2C_CH_STATUS_FLAG_STOP_CONDITION_RECEIVED) {
+        }
+        if (flag_status & (uint32_t)XMC_I2C_CH_STATUS_FLAG_STOP_CONDITION_RECEIVED) {
             XMC_I2C_CH_ClearStatusFlag(XMC_I2C_config->channel,
                                        XMC_I2C_CH_STATUS_FLAG_STOP_CONDITION_RECEIVED);
-            
+
             noInterrupts();
-           while(pre_rx_ringBuffer.available()) {
+            while (pre_rx_ringBuffer.available()) {
                 rx_ringBuffer.store_char(pre_rx_ringBuffer.read_char());
             }
             interrupts();
@@ -424,27 +470,22 @@ void TwoWire::ProtocolHandler(void) {
     }
 }
 
-void TwoWire::OnReceiveService( uint8_t numBytes) {
-    if (user_onReceive && numBytes >0) {
-    user_onReceive(numBytes);
-}
+void TwoWire::OnReceiveService(uint8_t numBytes) {
+    if (user_onReceive && numBytes > 0) {
+        user_onReceive(numBytes);
+    }
 }
 
 void TwoWire::OnRequestService(void) {
     if (user_onRequest) {
         tx_ringBuffer.clear();
-    user_onRequest();
+        user_onRequest();
     }
-    
 }
 
-void TwoWire::onReceive(void (*function)(int)) { 
-    user_onReceive = function; 
-}
+void TwoWire::onReceive(void (*function)(int)) { user_onReceive = function; }
 
-void TwoWire::onRequest(void (*function)(void)) { 
-    user_onRequest = function; 
-}
+void TwoWire::onRequest(void (*function)(void)) { user_onRequest = function; }
 
 /*
  *   Interrupt handler for xmc devices:

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -239,11 +239,16 @@ uint8_t TwoWire::endTransmission(bool sendStop) {
         do {
             StatusFlag = XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel);
             // Check for NACK, indicates that no slave with desired address is on the bus
-            if (this->hasError == true || timeout == 0) {
-                this->hasError = false;
-                inRepStart = false;
+            if(StatusFlag & XMC_I2C_CH_STATUS_FLAG_NACK_RECEIVED) {
+                this->hasError = true;
                 flush();
-                return 1;
+                return 2; // NACK received
+            }
+
+            if(timeout == 0) {
+                this->hasError = true;
+                flush();
+                return 4; // Timeout
             }
             timeout--;
         } while ((StatusFlag & XMC_I2C_CH_STATUS_FLAG_ACK_RECEIVED) == 0U);
@@ -258,7 +263,7 @@ uint8_t TwoWire::endTransmission(bool sendStop) {
                 this->hasError = false;
                 inRepStart = false;
                 flush();
-                return 1;
+                return 4;
             }
             timeout--;
         }

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -21,15 +21,6 @@ TwoWire::TwoWire(XMC_I2C_t *conf) {
     pre_rx_ringBuffer.clear();
 }
 
-void TwoWire::resetBus() {
-    end();
-    if(isMaster) {
-        begin();
-    }else {
-        begin(slaveAddress);
-    }
-}
-
 void TwoWire::begin(void) {
     // To-Do for future work need to check
     // Check if desire USIC channel is already in use 
@@ -242,7 +233,6 @@ uint8_t TwoWire::endTransmission(bool sendStop) {
             StatusFlag = XMC_I2C_CH_GetStatusFlag(XMC_I2C_config->channel);
             // Check for NACK, indicates that no slave with desired address is on the bus
             if(hasError || (millis() - start > timeout)) {
-                resetBus();
                 flush();
                 return 5; // NACK received
             }

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -133,7 +133,6 @@ size_t  TwoWire::requestFrom(uint8_t address, size_t quantity, bool sendStop) {
         }
         return 0;
     }
-    //beginTransmission(address);
     if (quantity > BUFFER_LENGTH) {
         quantity = BUFFER_LENGTH;
     }
@@ -251,8 +250,6 @@ uint8_t TwoWire::endTransmission(bool sendStop) {
 
         if(StatusFlag & XMC_I2C_CH_STATUS_FLAG_NACK_RECEIVED) {
             // NACK received, slave is not present
-            // this->hasError = true;
-            // inRepStart = false;
             flush();
             return 2; // NACK received
         }

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -51,7 +51,6 @@ private:
     void (*user_onReceive)(int);
     void OnRequestService(void);
     void OnReceiveService(uint8_t numBytes);
-    void resetBus();
 };
 
 extern TwoWire Wire;

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -5,7 +5,7 @@
 #include "api/RingBuffer.h"
 #include "api/HardwareI2C.h"
 
-#define WIRE_COMMUNICATION_TIMEOUT 5000u
+#define WIRE_COMMUNICATION_TIMEOUT 1000u
 #define BUFFER_LENGTH 64
 
 class TwoWire : public arduino::HardwareI2C {

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -5,9 +5,9 @@
 #include "api/RingBuffer.h"
 #include "api/HardwareI2C.h"
 
-#define WIRE_COMMUNICATION_TIMEOUT 1000u
-#define BUFFER_LENGTH 64
-
+#define WIRE_COMMUNICATION_TIMEOUT 5000u
+#define BUFFER_LENGTH 256
+#define WIRE_HAS_END 1
 class TwoWire : public arduino::HardwareI2C {
 public:
     bool volatile hasError;
@@ -21,7 +21,7 @@ public:
     uint8_t endTransmission(bool);
     size_t  requestFrom(uint8_t, size_t);
     size_t  requestFrom(uint8_t, size_t, bool);
-    size_t  requestFrom(uint8_t, size_t, uint32_t, uint8_t, bool);
+    // size_t  requestFrom(uint8_t, size_t, uint32_t, uint8_t, bool);
     virtual size_t write(uint8_t);
     virtual size_t write(const uint8_t *, size_t);
      int available(void);
@@ -51,7 +51,8 @@ private:
     void (*user_onRequest)(void);
     void (*user_onReceive)(int);
     void OnRequestService(void);
-    void OnReceiveService(void);
+    void OnReceiveService(uint8_t numBytes);
+    void resetBus();
 };
 
 extern TwoWire Wire;

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -21,7 +21,6 @@ public:
     uint8_t endTransmission(bool);
     size_t  requestFrom(uint8_t, size_t);
     size_t  requestFrom(uint8_t, size_t, bool);
-    // size_t  requestFrom(uint8_t, size_t, uint32_t, uint8_t, bool);
     virtual size_t write(uint8_t);
     virtual size_t write(const uint8_t *, size_t);
      int available(void);

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -8,6 +8,7 @@
 #define WIRE_COMMUNICATION_TIMEOUT 5000u
 #define BUFFER_LENGTH 256
 #define WIRE_HAS_END 1
+
 class TwoWire : public arduino::HardwareI2C {
 public:
     bool volatile hasError;
@@ -19,20 +20,21 @@ public:
     void beginTransmission(uint8_t);
     uint8_t endTransmission(void);
     uint8_t endTransmission(bool);
-    size_t  requestFrom(uint8_t, size_t);
-    size_t  requestFrom(uint8_t, size_t, bool);
+    size_t requestFrom(uint8_t, size_t);
+    size_t requestFrom(uint8_t, size_t, bool);
     virtual size_t write(uint8_t);
     virtual size_t write(const uint8_t *, size_t);
-     int available(void);
-     int read(void);
-     int peek(void);
-     void flush(void);
+    int available(void);
+    int read(void);
+    int peek(void);
+    void flush(void);
     void onReceive(void (*)(int));
     void onRequest(void (*)(void));
     void ReceiveHandler(void);
     void ProtocolHandler(void);
 
     using Print::write;
+
 private:
     XMC_I2C_t *XMC_I2C_config;
 
@@ -40,13 +42,13 @@ private:
     bool inRepStart;
     uint8_t transmitting;
     uint16_t timeout;
-    arduino::RingBufferN < BUFFER_LENGTH > rx_ringBuffer;
-    arduino::RingBufferN < BUFFER_LENGTH > tx_ringBuffer;
-    arduino::RingBufferN < BUFFER_LENGTH > pre_rx_ringBuffer;
-    
+    arduino::RingBufferN<BUFFER_LENGTH> rx_ringBuffer;
+    arduino::RingBufferN<BUFFER_LENGTH> tx_ringBuffer;
+    arduino::RingBufferN<BUFFER_LENGTH> pre_rx_ringBuffer;
+
     uint8_t slaveAddress;
     uint8_t txAddress;
-    
+
     void (*user_onRequest)(void);
     void (*user_onReceive)(int);
     void OnRequestService(void);

--- a/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
+++ b/variants/XMC4700/config/XMC4700_Relax_Kit/pins_arduino.h
@@ -426,180 +426,180 @@ Uart Serial(&XMC_UART_0);
 // On-Board port
 Uart Serial1(&XMC_UART_1);
 
-    // // Three SPI instances possible
-    // XMC_SPI_t XMC_SPI_0 = {
-    //     .channel = XMC_SPI2_CH0,
-    //     .channel_config = {.baudrate = 20003906U,
-    //                        .bus_mode = (XMC_SPI_CH_BUS_MODE_t)XMC_SPI_CH_BUS_MODE_MASTER,
-    //                        .selo_inversion = XMC_SPI_CH_SLAVE_SEL_INV_TO_MSLS,
-    //                        .parity_mode = XMC_USIC_CH_PARITY_MODE_NONE},
-    //     .mosi = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)8},
-    //     .mosi_config = {.mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT1,
-    //                     .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-    //                     .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM},
-    //     .miso = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)7},
-    //     .miso_config =
-    //         {
-    //             .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
-    //         },
-    //     .input_source = XMC_INPUT_C,
-    //     .sclkout = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)9},
-    //     .sclkout_config = {.mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT1,
-    //                        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-    //                        .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM},
-    // };
+// // Three SPI instances possible
+// XMC_SPI_t XMC_SPI_0 = {
+//     .channel = XMC_SPI2_CH0,
+//     .channel_config = {.baudrate = 20003906U,
+//                        .bus_mode = (XMC_SPI_CH_BUS_MODE_t)XMC_SPI_CH_BUS_MODE_MASTER,
+//                        .selo_inversion = XMC_SPI_CH_SLAVE_SEL_INV_TO_MSLS,
+//                        .parity_mode = XMC_USIC_CH_PARITY_MODE_NONE},
+//     .mosi = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)8},
+//     .mosi_config = {.mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT1,
+//                     .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
+//                     .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM},
+//     .miso = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)7},
+//     .miso_config =
+//         {
+//             .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
+//         },
+//     .input_source = XMC_INPUT_C,
+//     .sclkout = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)9},
+//     .sclkout_config = {.mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT1,
+//                        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
+//                        .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM},
+// };
 
-    // XMC_SPI_t XMC_SPI_1 = {
-    //     .channel = XMC_SPI0_CH1,
-    //     .channel_config = {.baudrate = 20003906U,
-    //                        .bus_mode = (XMC_SPI_CH_BUS_MODE_t)XMC_SPI_CH_BUS_MODE_MASTER,
-    //                        .selo_inversion = XMC_SPI_CH_SLAVE_SEL_INV_TO_MSLS,
-    //                        .parity_mode = XMC_USIC_CH_PARITY_MODE_NONE},
-    //     .mosi = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)5},
-    //     .mosi_config = {.mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT4,
-    //                     .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-    //                     .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM},
-    //     .miso = {.port = (XMC_GPIO_PORT_t *)PORT4_BASE, .pin = (uint8_t)0},
-    //     .miso_config =
-    //         {
-    //             .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
-    //         },
-    //     .input_source = XMC_INPUT_E,
-    //     .sclkout = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)6},
-    //     .sclkout_config = {.mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT4,
-    //                        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-    //                        .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM},
-    // };
+// XMC_SPI_t XMC_SPI_1 = {
+//     .channel = XMC_SPI0_CH1,
+//     .channel_config = {.baudrate = 20003906U,
+//                        .bus_mode = (XMC_SPI_CH_BUS_MODE_t)XMC_SPI_CH_BUS_MODE_MASTER,
+//                        .selo_inversion = XMC_SPI_CH_SLAVE_SEL_INV_TO_MSLS,
+//                        .parity_mode = XMC_USIC_CH_PARITY_MODE_NONE},
+//     .mosi = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)5},
+//     .mosi_config = {.mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT4,
+//                     .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
+//                     .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM},
+//     .miso = {.port = (XMC_GPIO_PORT_t *)PORT4_BASE, .pin = (uint8_t)0},
+//     .miso_config =
+//         {
+//             .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
+//         },
+//     .input_source = XMC_INPUT_E,
+//     .sclkout = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)6},
+//     .sclkout_config = {.mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT4,
+//                        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
+//                        .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM},
+// };
 
-    // XMC_SPI_t XMC_SPI_2 = {
-    //     .channel = XMC_SPI2_CH1,
-    //     .channel_config = {.baudrate = 20003906U,
-    //                        .bus_mode = (XMC_SPI_CH_BUS_MODE_t)XMC_SPI_CH_BUS_MODE_MASTER,
-    //                        .selo_inversion = XMC_SPI_CH_SLAVE_SEL_INV_TO_MSLS,
-    //                        .parity_mode = XMC_USIC_CH_PARITY_MODE_NONE},
-    //     .mosi = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)11},
-    //     .mosi_config = {.mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT1,
-    //                     .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-    //                     .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM},
-    //     .miso = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)12},
-    //     .miso_config =
-    //         {
-    //             .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
-    //         },
-    //     .input_source = XMC_INPUT_D,
-    //     .sclkout = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)13},
-    //     .sclkout_config = {.mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT1,
-    //                        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-    //                        .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM},
-    // };
+// XMC_SPI_t XMC_SPI_2 = {
+//     .channel = XMC_SPI2_CH1,
+//     .channel_config = {.baudrate = 20003906U,
+//                        .bus_mode = (XMC_SPI_CH_BUS_MODE_t)XMC_SPI_CH_BUS_MODE_MASTER,
+//                        .selo_inversion = XMC_SPI_CH_SLAVE_SEL_INV_TO_MSLS,
+//                        .parity_mode = XMC_USIC_CH_PARITY_MODE_NONE},
+//     .mosi = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)11},
+//     .mosi_config = {.mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT1,
+//                     .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
+//                     .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM},
+//     .miso = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)12},
+//     .miso_config =
+//         {
+//             .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
+//         },
+//     .input_source = XMC_INPUT_D,
+//     .sclkout = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)13},
+//     .sclkout_config = {.mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT1,
+//                        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
+//                        .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM},
+// };
 
-    // Only two serial objects are possible: Serial and Serial1 so anymore serial interfaces has to
-    // overwrite/reuse the existing serial objects
-    //  Will overwrite Serial
-    // XMC_SPI_t XMC_SPI_3 =
-    //{
-    //     .channel          = XMC_SPI0_CH0,
-    //     .channel_config   = {
-    //         .baudrate = 20003906U,
-    //         .bus_mode = (XMC_SPI_CH_BUS_MODE_t)XMC_SPI_CH_BUS_MODE_MASTER,
-    //         .selo_inversion = XMC_SPI_CH_SLAVE_SEL_INV_TO_MSLS,
-    //         .parity_mode = XMC_USIC_CH_PARITY_MODE_NONE
-    //     },
-    //     .mosi             = {
-    //         .port = (XMC_GPIO_PORT_t*)PORT5_BASE,
-    //         .pin  = (uint8_t)1
-    //     },
-    //     .mosi_config      = {
-    //         .mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT1,
-    //         .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-    //         .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM
-    //     },
-    //     .miso             = {
-    //         .port = (XMC_GPIO_PORT_t*)PORT5_BASE,
-    //         .pin  = (uint8_t)0
-    //     },
-    //     .miso_config      = {
-    //         .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
-    //     },
-    //     .input_source     = XMC_INPUT_D,
-    //     .sclkout = {
-    //         .port = (XMC_GPIO_PORT_t*)PORT0_BASE,
-    //         .pin  = (uint8_t)8
-    //     },
-    //     .sclkout_config   = {
-    //         .mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT2,
-    //         .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-    //         .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM
-    //     },
-    // };
+// Only two serial objects are possible: Serial and Serial1 so anymore serial interfaces has to
+// overwrite/reuse the existing serial objects
+//  Will overwrite Serial
+// XMC_SPI_t XMC_SPI_3 =
+//{
+//     .channel          = XMC_SPI0_CH0,
+//     .channel_config   = {
+//         .baudrate = 20003906U,
+//         .bus_mode = (XMC_SPI_CH_BUS_MODE_t)XMC_SPI_CH_BUS_MODE_MASTER,
+//         .selo_inversion = XMC_SPI_CH_SLAVE_SEL_INV_TO_MSLS,
+//         .parity_mode = XMC_USIC_CH_PARITY_MODE_NONE
+//     },
+//     .mosi             = {
+//         .port = (XMC_GPIO_PORT_t*)PORT5_BASE,
+//         .pin  = (uint8_t)1
+//     },
+//     .mosi_config      = {
+//         .mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT1,
+//         .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
+//         .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM
+//     },
+//     .miso             = {
+//         .port = (XMC_GPIO_PORT_t*)PORT5_BASE,
+//         .pin  = (uint8_t)0
+//     },
+//     .miso_config      = {
+//         .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
+//     },
+//     .input_source     = XMC_INPUT_D,
+//     .sclkout = {
+//         .port = (XMC_GPIO_PORT_t*)PORT0_BASE,
+//         .pin  = (uint8_t)8
+//     },
+//     .sclkout_config   = {
+//         .mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT2,
+//         .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
+//         .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM
+//     },
+// };
 
-    // Will overwrite Serial1
-    // XMC_SPI_t XMC_SPI_4 =
-    //{
-    //    .channel          = XMC_SPI1_CH0,
-    //    .channel_config   = {
-    //        .baudrate = 20003906U,
-    //        .bus_mode = (XMC_SPI_CH_BUS_MODE_t)XMC_SPI_CH_BUS_MODE_MASTER,
-    //        .selo_inversion = XMC_SPI_CH_SLAVE_SEL_INV_TO_MSLS,
-    //        .parity_mode = XMC_USIC_CH_PARITY_MODE_NONE
-    //    },
-    //    .mosi             = {
-    //        .port = (XMC_GPIO_PORT_t*)PORT0_BASE,
-    //        .pin  = (uint8_t)5
-    //    },
-    //    .mosi_config      = {
-    //        .mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT2,
-    //        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-    //        .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM
-    //    },
-    //    .miso             = {
-    //        .port = (XMC_GPIO_PORT_t*)PORT0_BASE,
-    //        .pin  = (uint8_t)4
-    //    },
-    //    .miso_config      = {
-    //        .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
-    //    },
-    //    .input_source     = XMC_INPUT_A,
-    //    .sclkout = {
-    //        .port = (XMC_GPIO_PORT_t*)PORT0_BASE,
-    //        .pin  = (uint8_t)11
-    //    },
-    //    .sclkout_config   = {
-    //        .mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT2,
-    //        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
-    //        .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM
-    //    },
-    //};
+// Will overwrite Serial1
+// XMC_SPI_t XMC_SPI_4 =
+//{
+//    .channel          = XMC_SPI1_CH0,
+//    .channel_config   = {
+//        .baudrate = 20003906U,
+//        .bus_mode = (XMC_SPI_CH_BUS_MODE_t)XMC_SPI_CH_BUS_MODE_MASTER,
+//        .selo_inversion = XMC_SPI_CH_SLAVE_SEL_INV_TO_MSLS,
+//        .parity_mode = XMC_USIC_CH_PARITY_MODE_NONE
+//    },
+//    .mosi             = {
+//        .port = (XMC_GPIO_PORT_t*)PORT0_BASE,
+//        .pin  = (uint8_t)5
+//    },
+//    .mosi_config      = {
+//        .mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT2,
+//        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
+//        .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM
+//    },
+//    .miso             = {
+//        .port = (XMC_GPIO_PORT_t*)PORT0_BASE,
+//        .pin  = (uint8_t)4
+//    },
+//    .miso_config      = {
+//        .mode = XMC_GPIO_MODE_INPUT_TRISTATE,
+//    },
+//    .input_source     = XMC_INPUT_A,
+//    .sclkout = {
+//        .port = (XMC_GPIO_PORT_t*)PORT0_BASE,
+//        .pin  = (uint8_t)11
+//    },
+//    .sclkout_config   = {
+//        .mode = XMC_GPIO_MODE_OUTPUT_PUSH_PULL_ALT2,
+//        .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH,
+//        .output_strength = XMC_GPIO_OUTPUT_STRENGTH_MEDIUM
+//    },
+//};
 
-    //Two I2C instances possible
-    XMC_I2C_t XMC_I2C_0 = {.channel = XMC_I2C1_CH1,
-                           .channel_config = {.baudrate = (uint32_t)(100000U), .address = 0U},
-                           .sda = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)15},
-                           .sda_config = {.mode = XMC_GPIO_MODE_OUTPUT_OPEN_DRAIN_ALT2,
-                                          .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH},
-                           .scl = {.port = (XMC_GPIO_PORT_t *)PORT0_BASE, .pin = (uint8_t)13},
-                           .scl_config = {.mode = XMC_GPIO_MODE_OUTPUT_OPEN_DRAIN_ALT2,
-                                          .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH},
-                           .input_source_dx0 = XMC_INPUT_A,
-                           .input_source_dx1 = XMC_INPUT_B,
-                           .slave_receive_irq_num = (IRQn_Type)91,
-                           .slave_receive_irq_service_request = 1,
-                           .protocol_irq_num = (IRQn_Type)92,
-                           .protocol_irq_service_request = 2};
-    XMC_I2C_t XMC_I2C_1 = {.channel = XMC_I2C1_CH0,
-                           .channel_config = {.baudrate = (uint32_t)(100000U), .address = 0U},
-                           .sda = {.port = (XMC_GPIO_PORT_t *)PORT0_BASE, .pin = (uint8_t)5},
-                           .sda_config = {.mode = XMC_GPIO_MODE_OUTPUT_OPEN_DRAIN_ALT2,
-                                          .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH},
-                           .scl = {.port = (XMC_GPIO_PORT_t *)PORT0_BASE, .pin = (uint8_t)11},
-                           .scl_config = {.mode = XMC_GPIO_MODE_OUTPUT_OPEN_DRAIN_ALT2,
-                                          .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH},
-                           .input_source_dx0 = XMC_INPUT_B,
-                           .input_source_dx1 = XMC_INPUT_A,
-                           .slave_receive_irq_num = (IRQn_Type)93,
-                           .slave_receive_irq_service_request = 3,
-                           .protocol_irq_num = (IRQn_Type)94,
-                           .protocol_irq_service_request = 4};
+// Two I2C instances possible
+XMC_I2C_t XMC_I2C_0 = {.channel = XMC_I2C1_CH1,
+                       .channel_config = {.baudrate = (uint32_t)(100000U), .address = 0U},
+                       .sda = {.port = (XMC_GPIO_PORT_t *)PORT3_BASE, .pin = (uint8_t)15},
+                       .sda_config = {.mode = XMC_GPIO_MODE_OUTPUT_OPEN_DRAIN_ALT2,
+                                      .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH},
+                       .scl = {.port = (XMC_GPIO_PORT_t *)PORT0_BASE, .pin = (uint8_t)13},
+                       .scl_config = {.mode = XMC_GPIO_MODE_OUTPUT_OPEN_DRAIN_ALT2,
+                                      .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH},
+                       .input_source_dx0 = XMC_INPUT_A,
+                       .input_source_dx1 = XMC_INPUT_B,
+                       .slave_receive_irq_num = (IRQn_Type)91,
+                       .slave_receive_irq_service_request = 1,
+                       .protocol_irq_num = (IRQn_Type)92,
+                       .protocol_irq_service_request = 2};
+XMC_I2C_t XMC_I2C_1 = {.channel = XMC_I2C1_CH0,
+                       .channel_config = {.baudrate = (uint32_t)(100000U), .address = 0U},
+                       .sda = {.port = (XMC_GPIO_PORT_t *)PORT0_BASE, .pin = (uint8_t)5},
+                       .sda_config = {.mode = XMC_GPIO_MODE_OUTPUT_OPEN_DRAIN_ALT2,
+                                      .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH},
+                       .scl = {.port = (XMC_GPIO_PORT_t *)PORT0_BASE, .pin = (uint8_t)11},
+                       .scl_config = {.mode = XMC_GPIO_MODE_OUTPUT_OPEN_DRAIN_ALT2,
+                                      .output_level = XMC_GPIO_OUTPUT_LEVEL_HIGH},
+                       .input_source_dx0 = XMC_INPUT_B,
+                       .input_source_dx1 = XMC_INPUT_A,
+                       .slave_receive_irq_num = (IRQn_Type)93,
+                       .slave_receive_irq_service_request = 3,
+                       .protocol_irq_num = (IRQn_Type)94,
+                       .protocol_irq_service_request = 4};
 
     // // XMC_I2S instance
     // XMC_I2S_t i2s_config = {.input_config = {.mode = XMC_GPIO_MODE_INPUT_TRISTATE,


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Implemented Ringbuffer, error handling in endTransmission() function.

Related Issue
Every 20 to 30 seconds getting one or two iteration fail during Master pingpong and slavepingpong test case running. Suspecting timeout mechanism.
<img width="1917" height="738" alt="image" src="https://github.com/user-attachments/assets/1c388d4d-786f-451a-9a22-9ac1156dfd19" />

Context
Tested with two XMC 4700 board which one is master and one is slave, used 4.7K ohm resistor 
and Tested with Mastersender  - slavereceiver and Master Receiver - Slave sender arduino examples this is also working.
<img width="1546" height="685" alt="image" src="https://github.com/user-attachments/assets/0f2f4f0e-5c6a-4f60-87a7-22ea00e32ae8" />


this screenshot of single board pingpong test multiple wire pins
<img width="417" height="937" alt="image" src="https://github.com/user-attachments/assets/72f1f390-6e50-40b8-a27a-ec06c83e137d" />
