### PR TITLE
libraries/Wire/src: Fixed iic scan bug.

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -290,6 +290,7 @@ uint8_t TwoWire::endTransmission(bool sendStop) {
     }
 
     if (sendStop) {
+        delay(1);
         XMC_I2C_CH_MasterStop(XMC_I2C_config->channel);
         uint32_t start = millis();
         while (XMC_USIC_CH_GetTransmitBufferStatus(XMC_I2C_config->channel) ==

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -290,7 +290,7 @@ uint8_t TwoWire::endTransmission(bool sendStop) {
     }
 
     if (sendStop) {
-        delay(1);
+        delay(1); // Allow time for the I2C Scan
         XMC_I2C_CH_MasterStop(XMC_I2C_config->channel);
         uint32_t start = millis();
         while (XMC_USIC_CH_GetTransmitBufferStatus(XMC_I2C_config->channel) ==


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Regarding I2C scan not working in pervious version , here its fixed after added 1ms delay , actually its not stable so i got so many address, after added delay its resolved
Jira ticket: https://jirard.intra.infineon.com/browse/DESMAKERS-4423

Related Issue
I2C scan not worked pervious version and 4.0.0 not stable.
This image is not stable in 4.0.0
<img width="347" height="451" alt="image" src="https://github.com/user-attachments/assets/afb6946c-7e21-47bd-a9c2-3539d2c01437" />


Context
<img width="918" height="501" alt="image" src="https://github.com/user-attachments/assets/23f40ad8-a439-453f-86bb-083da78cb111" />
Here tested with 4700 , connected 2 I2C slave, one is OLED and another one pressure sensor DPS422