### PR TITLE
cores/xmc: Declared sbrk function.

### DIFF
--- a/cores/xmc/main.cpp
+++ b/cores/xmc/main.cpp
@@ -26,6 +26,12 @@
 //****************************************************************************
 #include "Arduino.h"
 
+// work around to use new operator
+extern "C" void *_sbrk(int incr);
+void dummy_sbrk_caller() __attribute__((__used__));
+
+void dummy_sbrk_caller() { _sbrk(0); }
+
 // Weak empty variant initialization function.
 // May be redefined by variant files.
 void initVariant() __attribute__((weak));


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Resolved compiling issue in 1400 XMC boards.

Related Issue
In 1400 series board not compiled due to HEAP not end in linker file. _sbrk function not declared anywhere in 4.0.0 prerelease so met undefined reference "end" error.  After declared _sbrk function name in main.cpp its resolved.
Error:
/home/mdin/.arduino15/packages/Infineon/tools/arm-none-eabi-gcc/10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: /home/mdin/.arduino15/packages/Infineon/tools/arm-none-eabi-gcc/10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/lib/thumb/v6-m/nofp/libnosys.a(sbrk.o): in function `_sbrk':
sbrk.c:(.text._sbrk+0x18): undefined reference to `end'
collect2: error: ld returned 1 exit status

Context
Tested with 1400 2Go board
<img width="570" height="366" alt="image" src="https://github.com/user-attachments/assets/68a6b13e-5f24-476c-bebd-9e6ad079715d" />
