### PR TITLE
Xmc interrupt uart fix

### DIFF
--- a/cores/xmc/WInterrupts.c
+++ b/cores/xmc/WInterrupts.c
@@ -125,11 +125,16 @@ void attachInterrupt(pin_size_t interrupt_num, voidFuncPtr callback, PinStatus m
     XMC_CCU4_EnableClock(pin_irq.ccu, pin_irq.slice_num);
 
     if (pin_irq.irq_num == 0) {
-    #if defined(KIT_XMC11_BOOT_001) || defined(KIT_XMC1400_ARDUINO) || defined(KIT_XMC14_2GO)
+    #if  defined(KIT_XMC14_2GO)
         /* P1_4 external interrupt goes through USIC to CCU4 */
         XMC_USIC_CH_Enable(XMC_USIC0_CH1);
         XMC_USIC_CH_SetInputSource(XMC_USIC0_CH1, XMC_USIC_CH_INPUT_DX5, USIC0_C0_DX5_P1_4);
         XMC_USIC_CH_SetInputSource(XMC_USIC0_CH1, XMC_USIC_CH_INPUT_DX2, USIC0_C0_DX2_DX5INS);
+    #endif
+    #if defined(KIT_XMC11_BOOT_001) || defined(KIT_XMC1400_ARDUINO)
+        XMC_USIC_CH_Enable(XMC_USIC0_CH0);
+        XMC_USIC_CH_SetInputSource(XMC_USIC0_CH0, XMC_USIC_CH_INPUT_DX5, USIC0_C0_DX5_P1_4);
+        XMC_USIC_CH_SetInputSource(XMC_USIC0_CH0, XMC_USIC_CH_INPUT_DX2, USIC0_C0_DX2_DX5INS);
     #endif
         XMC_CCU4_SLICE_EnableMultipleEvents(pin_irq.slice, XMC_CCU4_SLICE_MULTI_IRQ_ID_EVENT0);
         XMC_CCU4_SLICE_SetInterruptNode(pin_irq.slice, XMC_CCU4_SLICE_IRQ_ID_EVENT0, 0);
@@ -141,15 +146,10 @@ void attachInterrupt(pin_size_t interrupt_num, voidFuncPtr callback, PinStatus m
         interrupt_0_cb = callback;
         NVIC_EnableIRQ(CCU40_0_IRQn);
     } else if (pin_irq.irq_num == 1) {
-    #if defined(KIT_XMC13_BOOT_001)
+    #if defined(KIT_XMC13_BOOT_001) || defined(KIT_XMC1400_ARDUINO)
         /* P0_13 external interrupt goes through USIC to CCU4 */
         XMC_USIC_CH_Enable(XMC_USIC0_CH0);
         XMC_USIC_CH_SetInputSource(XMC_USIC0_CH0, XMC_USIC_CH_INPUT_DX2, USIC0_C0_DX2_P0_13);
-    #endif
-    #if defined(KIT_XMC1400_ARDUINO)
-        /* P1_1 external interrupt goes through USIC to CCU4 */
-        XMC_USIC_CH_Enable(XMC_USIC0_CH1);
-        XMC_USIC_CH_SetInputSource(XMC_USIC0_CH1, XMC_USIC_CH_INPUT_DX2, USIC0_C1_DX2_P1_1);
     #endif
         XMC_CCU4_SLICE_EnableMultipleEvents(pin_irq.slice, XMC_CCU4_SLICE_MULTI_IRQ_ID_EVENT1);
         XMC_CCU4_SLICE_SetInterruptNode(pin_irq.slice, XMC_CCU4_SLICE_IRQ_ID_EVENT1, 1);

--- a/cores/xmc/WInterrupts.c
+++ b/cores/xmc/WInterrupts.c
@@ -127,9 +127,9 @@ void attachInterrupt(pin_size_t interrupt_num, voidFuncPtr callback, PinStatus m
     if (pin_irq.irq_num == 0) {
     #if defined(KIT_XMC11_BOOT_001) || defined(KIT_XMC1400_ARDUINO) || defined(KIT_XMC14_2GO)
         /* P1_4 external interrupt goes through USIC to CCU4 */
-        XMC_USIC_CH_Enable(XMC_USIC0_CH0);
-        XMC_USIC_CH_SetInputSource(XMC_USIC0_CH0, XMC_USIC_CH_INPUT_DX5, USIC0_C0_DX5_P1_4);
-        XMC_USIC_CH_SetInputSource(XMC_USIC0_CH0, XMC_USIC_CH_INPUT_DX2, USIC0_C0_DX2_DX5INS);
+        XMC_USIC_CH_Enable(XMC_USIC0_CH1);
+        XMC_USIC_CH_SetInputSource(XMC_USIC0_CH1, XMC_USIC_CH_INPUT_DX5, USIC0_C0_DX5_P1_4);
+        XMC_USIC_CH_SetInputSource(XMC_USIC0_CH1, XMC_USIC_CH_INPUT_DX2, USIC0_C0_DX2_DX5INS);
     #endif
         XMC_CCU4_SLICE_EnableMultipleEvents(pin_irq.slice, XMC_CCU4_SLICE_MULTI_IRQ_ID_EVENT0);
         XMC_CCU4_SLICE_SetInterruptNode(pin_irq.slice, XMC_CCU4_SLICE_IRQ_ID_EVENT0, 0);

--- a/docs/arduino-deviations.rst
+++ b/docs/arduino-deviations.rst
@@ -46,18 +46,9 @@ to be in INPUT Mode that needs Inputs.
 Interrupt
 +++++++++
 
-XMC1400 Kit for Arduino - Interrupt 1 and serial conflict
-When using the **KIT_XMC1400_ARDUINO** **Interrupt** 1 does not work when serial (UART) is used.
-The Pin Mapped to **Interrupt 1** shares the **same hardware bus configuration as UART**.
-
-**Impact:**
-
-- Interrupt will not trigger.
-- Serial communication also not work.
-  
-**Workarounds:**
-
-- use **Interrupt 0**
+XMC1400 Kit for Arduino - Interrupt 1 pin allocated to pin number - **7**
+.. code-block::
+   const byte interruptPin = 7; // for interrupt-1
 
 Wire/I2C Differences
 ++++++++++++++++++++

--- a/variants/XMC1400/config/KIT_XMC1400_ARDUINO/pins_arduino.h
+++ b/variants/XMC1400/config/KIT_XMC1400_ARDUINO/pins_arduino.h
@@ -110,9 +110,9 @@ extern uint8_t SCK;
 #define LED_BUILTIN LED1
 
 #define EXT_INTR_0 25
-#define EXT_INTR_1 3
+#define EXT_INTR_1 7
 
-#define digitalPinToInterrupt(p) ((p) == 25 ? 0 : ((p) == 3 ? 1 : -1))
+#define digitalPinToInterrupt(p) ((p) == 25 ? 0 : ((p) == 7 ? 1 : -1))
 
 /* Mapping interrupt handlers. Notice that XMC1400 can have interrupt handlers working in 3 modes,
    the defines below assumes the mode A. For details refer to assembly file and reference manual.
@@ -181,7 +181,7 @@ bool gpio_current_value[NUM_DIGITAL] = {false};
 
 const XMC_PIN_INTERRUPT_t mapping_interrupt[] = {
     /* 0  */ {CCU40, CCU40_CC40, 0, 0, CCU40_IN0_U0C0_DX2INS},
-    /* 1  */ {CCU40, CCU40_CC41, 1, 1, CCU40_IN1_U0C1_DX2INS}};
+    /* 1  */ {CCU40, CCU40_CC40, 0, 1, CCU40_IN1_U0C1_DX2INS}};
 const uint8_t NUM_INTERRUPT = (sizeof(mapping_interrupt) / sizeof(XMC_PIN_INTERRUPT_t));
 
 /* Mapping of Arduino Pins to PWM4 channels as pin and index in PWM4 channel

--- a/variants/XMC1400/config/KIT_XMC14_2GO/pins_arduino.h
+++ b/variants/XMC1400/config/KIT_XMC14_2GO/pins_arduino.h
@@ -179,7 +179,7 @@ bool gpio_current_value[NUM_DIGITAL] = {false};
 
 /* Configurations of Interrupt */
 const XMC_PIN_INTERRUPT_t mapping_interrupt[] = {
-    /* 0  */ {CCU40, CCU40_CC40, 0, 0, CCU40_IN0_U0C0_DX2INS}};
+    /* 0  */ {CCU40, CCU40_CC41, 1, 0, CCU40_IN0_U0C0_DX2INS}};
 const uint8_t NUM_INTERRUPT = (sizeof(mapping_interrupt) / sizeof(XMC_PIN_INTERRUPT_t));
 
 /* Mapping of Arduino Pins to PWM4 channels as pin and index in PWM4 channel


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
https://jirard.intra.infineon.com/browse/DESMAKERS-4820
Code execution stopped after attachInterrupt in XMC1400 boards.  Due to use same channel name in uart and interrupt