### PR TITLE
cores/xmc: Add missing itoa/ltoa/utoa/ultoa implementation

### DIFF
--- a/cores/xmc/itoa.c
+++ b/cores/xmc/itoa.c
@@ -1,0 +1,173 @@
+/*
+  Copyright (c) 2011 Arduino.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+//****************************************************************************
+// @Project Includes
+//****************************************************************************
+#include "api/itoa.h"
+#include <string.h>
+
+//****************************************************************************
+// @Local Functions
+//****************************************************************************
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#if 0
+    /* reverse:  reverse string s in place */
+    static void reverse( char s[] )
+    {
+        int i, j ;
+        char c ;
+
+        for ( i = 0, j = strlen(s) - 1 ; i < j ; i++, j-- )
+        {
+            c = s[i] ;
+            s[i] = s[j] ;
+            s[j] = c ;
+        }
+    }
+
+    /* itoa:  convert n to characters in s */
+    extern void itoa( int n, char s[] )
+    {
+        int i, sign ;
+
+        if ( (sign = n) < 0 )  /* record sign */
+        {
+            n = -n;          /* make n positive */
+        }
+
+        i = 0;
+        do
+        {
+            /* generate digits in reverse order */
+            s[i++] = n % 10 + '0';   /* get next digit */
+        }
+        while ((n /= 10) > 0) ;       /* delete it */
+
+        if (sign < 0 )
+        {
+            s[i++] = '-';
+        }
+
+        s[i] = '\0';
+
+        reverse( s ) ;
+    }
+
+#else
+
+extern char *itoa(int value, char *string, int radix) { return ltoa(value, string, radix); }
+
+extern char *ltoa(long value, char *string, int radix) {
+    char tmp[33];
+    char *tp = tmp;
+    long i;
+    unsigned long v;
+    int sign;
+    char *sp;
+
+    if (string == NULL) {
+        return 0;
+    }
+
+    if (radix > 36 || radix <= 1) {
+        return 0;
+    }
+
+    sign = (radix == 10 && value < 0);
+    if (sign) {
+        v = -value;
+    } else {
+        v = (unsigned long)value;
+    }
+
+    while (v || tp == tmp) {
+        i = v % radix;
+        v = v / radix;
+        if (i < 10) {
+            *tp++ = i + '0';
+        } else {
+            *tp++ = i + 'a' - 10;
+        }
+    }
+
+    sp = string;
+
+    if (sign) {
+        *sp++ = '-';
+    }
+    while (tp > tmp) {
+        *sp++ = *--tp;
+    }
+    *sp = 0;
+
+    return string;
+}
+
+extern char *utoa(unsigned int value, char *string, int radix) {
+    return ultoa(value, string, radix);
+}
+
+extern char *ultoa(unsigned long value, char *string, int radix) {
+    char tmp[33];
+    char *tp = tmp;
+    long i;
+    unsigned long v = value;
+    char *sp;
+
+    if (string == NULL) {
+        return 0;
+    }
+
+    if (radix > 36 || radix <= 1) {
+        return 0;
+    }
+
+    while (v || tp == tmp) {
+        i = v % radix;
+        v = v / radix;
+        if (i < 10) {
+            *tp++ = i + '0';
+        } else {
+            *tp++ = i + 'a' - 10;
+        }
+    }
+
+    sp = string;
+
+    while (tp > tmp) {
+        *sp++ = *--tp;
+    }
+    *sp = 0;
+
+    return string;
+}
+#endif /* 0 */
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+//****************************************************************************
+//                                 END OF FILE
+//****************************************************************************
+


### PR DESCRIPTION
ArduinoCore-API (api/itoa.h) declares these functions but the XMC core did not provide an implementation, causing linker errors:
  undefined reference to 'ltoa'

Ported from the v3.x implementation (cores/itoa.c), updating the include path from 'itoa.h' to 'api/itoa.h' for the v4.x structure.

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

XMC-for-Arduino v3.x provided `cores/itoa.c` which implemented `itoa`, `ltoa`, `utoa`, and `ultoa`. When the core was restructured for v4.x (adopting ArduinoCore-API), the source file was not migrated to the new `cores/xmc/` directory.

However, ArduinoCore-API's `api/itoa.h` still declares these four functions, so any sketch or library that calls them (e.g. `String` class internals, `Serial.print` with integers) will result in an `undefined reference` linker error.

This PR restores the implementation by adding `cores/xmc/itoa.c`, ported from the v3.x version with the include path updated to `api/itoa.h` to match the v4.x structure.